### PR TITLE
UI: hand-tune database analysis pages

### DIFF
--- a/analyzer/templates/analyzer/contextualized_results.html
+++ b/analyzer/templates/analyzer/contextualized_results.html
@@ -1,282 +1,186 @@
 {% extends 'analyzer/base.html' %}
 {% load static %}
 
-{% block title %}Query Analysis Results - QueryGrade{% endblock %}
-
-
+{% block title %}Contextualized results · QueryGrade{% endblock %}
 
 {% block content %}
-<div class="max-w-7xl mx-auto px-4 mt-4">
-    <!-- Grade Display -->
-    <div class="flex flex-wrap gap-4">
-        <div class="md:flex-1">
-            <div class="grade-display grade-{{ analysis.grade }}">
-                <div>{{ analysis.grade }}</div>
-                <div style="font-size: 1.5rem; margin-top: -1rem;">{{ analysis.score }}/100</div>
-            </div>
-        </div>
-        <div class="md:flex-1">
-            <div class="flex flex-wrap gap-4">
-                <div class="md:flex-1">
-                    <div class="metric-bg-white rounded-lg border border-gray-200">
-                        <div class="metric-value">{{ query.query_type|default:"Unknown"|title }}</div>
-                        <div class="metric-label">Query Type</div>
-                    </div>
-                </div>
-                <div class="md:flex-1">
-                    <div class="metric-bg-white rounded-lg border border-gray-200">
-                        <div class="metric-value">{{ query.estimated_complexity|default:"Unknown"|title }}</div>
-                        <div class="metric-label">Complexity</div>
-                    </div>
-                </div>
-                <div class="md:flex-1">
-                    <div class="metric-bg-white rounded-lg border border-gray-200">
-                        <div class="metric-value">
-                            {% if analysis.execution_time_ms %}{{ analysis.execution_time_ms }}ms{% else %}N/A{% endif %}
-                        </div>
-                        <div class="metric-label">Analysis Time</div>
-                    </div>
-                </div>
-            </div>
-        </div>
+<div class="space-y-6">
+  <header class="flex flex-wrap items-center justify-between gap-3">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900">⭐ Contextualized analysis</h1>
+      {% if db_config %}<p class="mt-1 text-sm text-gray-500">Analyzed against <strong>{{ db_config.engine|title }}</strong> · {{ db_config.name }}</p>{% endif %}
+    </div>
+    <div class="flex flex-wrap gap-2 text-sm">
+      <a href="{% url 'query_with_context' %}" class="px-3 py-1.5 rounded border border-gray-300 text-gray-700 hover:bg-gray-50">New analysis</a>
+      <a href="{% url 'database_schema' %}" class="px-3 py-1.5 rounded border border-gray-300 text-gray-700 hover:bg-gray-50">View schema</a>
+    </div>
+  </header>
+
+  {% with g=analysis.grade|lower %}
+  <section class="bg-white rounded-lg border border-gray-200 p-6 flex flex-col md:flex-row gap-6">
+    <div class="flex-shrink-0 flex flex-col items-center justify-center text-center md:w-48 p-4 rounded-lg
+      {% if g == 'a' %}bg-emerald-50 ring-1 ring-emerald-200
+      {% elif g == 'b' %}bg-lime-50 ring-1 ring-lime-200
+      {% elif g == 'c' %}bg-amber-50 ring-1 ring-amber-200
+      {% elif g == 'd' %}bg-orange-50 ring-1 ring-orange-200
+      {% else %}bg-red-50 ring-1 ring-red-200{% endif %}">
+      <div class="text-6xl font-bold leading-none
+        {% if g == 'a' %}text-emerald-700{% elif g == 'b' %}text-lime-700{% elif g == 'c' %}text-amber-700{% elif g == 'd' %}text-orange-700{% else %}text-red-700{% endif %}">{{ analysis.grade }}</div>
+      <div class="mt-2 text-2xl font-semibold text-gray-900">{{ analysis.score|floatformat:1 }}<span class="text-base text-gray-500">/100</span></div>
     </div>
 
-    <!-- Context Information -->
-    {% if has_context %}
-    <div class="flex flex-wrap gap-4">
-        <div class="col-12">
-            <div class="bg-white rounded-lg border border-gray-200">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold context-header">
-                    <h5 class="mb-0">
-                        <i class="fas fa-link me-2"></i>
-                        Database Context Analysis
-                        <span class="context-badge">Connected to {{ db_config.name }}</span>
-                    </h5>
-                </div>
-                <div class="p-4">
-                    <!-- Tables and Columns Referenced -->
-                    {% if context_analysis.tables_referenced %}
-                    <div class="mb-3">
-                        <h6><i class="fas fa-min-w-full text-sm text-indigo-600 me-2"></i>Tables Referenced</h6>
-                        {% for min-w-full text-sm in context_analysis.tables_referenced %}
-                            <span class="min-w-full text-sm-reference">{{ min-w-full text-sm }}</span>
-                        {% endfor %}
-                    </div>
-                    {% endif %}
+    <div class="flex-1">
+      <h2 class="text-lg font-semibold text-gray-900">Summary</h2>
+      <dl class="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
+        <div><dt class="text-gray-500">Query type</dt><dd class="mt-0.5 font-medium text-gray-900">{{ query.query_type }}</dd></div>
+        <div><dt class="text-gray-500">Tables</dt><dd class="mt-0.5 font-medium text-gray-900">{{ query.table_count }}</dd></div>
+        <div><dt class="text-gray-500">Joins</dt><dd class="mt-0.5 font-medium text-gray-900">{{ query.join_count }}</dd></div>
+        <div><dt class="text-gray-500">Complexity</dt><dd class="mt-0.5 font-medium text-gray-900">{{ query.estimated_complexity }}/100</dd></div>
+        <div><dt class="text-gray-500">Analysis time</dt><dd class="mt-0.5 font-medium text-gray-900">{% if analysis.execution_time_ms %}{{ analysis.execution_time_ms }}ms{% else %}—{% endif %}</dd></div>
+        <div><dt class="text-gray-500">Issues</dt><dd class="mt-0.5 font-medium text-gray-900">{{ analysis.issues_found|length }}</dd></div>
+      </dl>
+    </div>
+  </section>
+  {% endwith %}
 
-                    {% if context_analysis.columns_referenced %}
-                    <div class="mb-3">
-                        <h6><i class="fas fa-columns text-purple me-2"></i>Columns Referenced</h6>
-                        {% for column in context_analysis.columns_referenced %}
-                            <span class="column-reference">{{ column }}</span>
-                        {% endfor %}
-                    </div>
-                    {% endif %}
+  <section class="bg-white rounded-lg border border-gray-200">
+    <div class="flex items-center justify-between px-5 py-3 border-b border-gray-100">
+      <h3 class="text-sm font-semibold text-gray-700">Analyzed query</h3>
+    </div>
+    <pre class="overflow-x-auto p-5 text-sm font-mono text-gray-100 bg-gray-900 rounded-b-lg"><code>{{ query.sql_text }}</code></pre>
+  </section>
 
-                    <!-- Schema Analysis -->
-                    {% if context_analysis.schema_analysis %}
-                    <div class="mb-3">
-                        <h6><i class="fas fa-chart-bar text-info me-2"></i>Schema Analysis</h6>
-                        <div class="flex flex-wrap gap-4">
-                            {% for min-w-full text-sm, info in context_analysis.schema_analysis.items %}
-                            <div class="md:flex-1 mb-2">
-                                <div class="border rounded p-2">
-                                    <strong>{{ min-w-full text-sm }}</strong><br>
-                                    <small class="text-gray-500">
-                                        {% if info.row_count %}{{ info.row_count|floatformat:0 }} rows • {% endif %}
-                                        {% if info.size_mb %}{{ info.size_mb }} MB • {% endif %}
-                                        {{ info.columns }} columns • {{ info.indexes }} indexes
-                                        {% if not info.has_primary_key %} • <span class="text-red-600">No Primary Key</span>{% endif %}
-                                    </small>
-                                </div>
-                            </div>
-                            {% endfor %}
-                        </div>
-                    </div>
-                    {% endif %}
+  {% if has_context %}
+  <section class="bg-gradient-to-br from-indigo-50 to-purple-50 rounded-lg border border-indigo-200 p-5">
+    <h3 class="text-base font-semibold text-indigo-900 flex items-center gap-2"><span>🗄️</span><span>Database context</span></h3>
 
-                    <!-- Context-Specific Recommendations -->
-                    {% if context_analysis.recommendations %}
-                    <div class="mb-3">
-                        <h6><i class="fas fa-lightbulb text-emerald-600 me-2"></i>Context-Aware Recommendations</h6>
-                        {% for recommendation in context_analysis.recommendations %}
-                            <div class="context-recommendation">
-                                <i class="fas fa-magic me-2"></i>{{ recommendation }}
-                            </div>
-                        {% endfor %}
-                    </div>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
+    {% if context_analysis.tables_referenced %}
+    <div class="mt-4">
+      <h4 class="text-xs font-semibold uppercase text-indigo-700 mb-2">Tables referenced</h4>
+      <div class="flex flex-wrap gap-1">
+        {% for tbl in context_analysis.tables_referenced %}
+        <span class="px-2 py-0.5 bg-white rounded text-xs font-mono text-indigo-800 ring-1 ring-indigo-200">{{ tbl }}</span>
+        {% endfor %}
+      </div>
     </div>
     {% endif %}
 
-    <!-- SQL Query -->
-    <div class="flex flex-wrap gap-4">
-        <div class="col-12">
-            <div class="bg-white rounded-lg border border-gray-200">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold">
-                    <h5 class="mb-0">
-                        <i class="fas fa-code me-2"></i>
-                        SQL Query
-                    </h5>
-                </div>
-                <div class="p-4">
-                    <div class="sql-code">{{ query.sql_text }}</div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Analysis Results -->
-    <div class="flex flex-wrap gap-4">
-        <!-- Issues Found -->
-        {% if analysis.issues_found %}
-        <div class="md:flex-1">
-            <div class="bg-white rounded-lg border border-gray-200">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold">
-                    <h5 class="mb-0">
-                        <i class="fas fa-exclamation-triangle me-2"></i>
-                        Issues Found
-                    </h5>
-                </div>
-                <div class="p-4">
-                    {% for issue in analysis.issues_found %}
-                        <div class="issue-item">
-                            <i class="fas fa-times-circle me-2"></i>{{ issue }}
-                        </div>
-                    {% endfor %}
-                </div>
-            </div>
-        </div>
-        {% endif %}
-
-        <!-- Recommendations -->
-        {% if analysis.recommendations %}
-        <div class="md:flex-1">
-            <div class="bg-white rounded-lg border border-gray-200">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold">
-                    <h5 class="mb-0">
-                        <i class="fas fa-lightbulb me-2"></i>
-                        Recommendations
-                    </h5>
-                </div>
-                <div class="p-4">
-                    {% for recommendation in analysis.recommendations %}
-                        <div class="recommendation-item">
-                            <i class="fas fa-arrow-right me-2"></i>{{ recommendation }}
-                        </div>
-                    {% endfor %}
-                </div>
-            </div>
-        </div>
-        {% endif %}
-    </div>
-
-    <!-- Performance Notes -->
-    {% if analysis.performance_notes %}
-    <div class="flex flex-wrap gap-4">
-        <div class="col-12">
-            <div class="bg-white rounded-lg border border-gray-200">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold">
-                    <h5 class="mb-0">
-                        <i class="fas fa-tachometer-alt me-2"></i>
-                        Performance Notes
-                    </h5>
-                </div>
-                <div class="p-4">
-                    <div class="performance-note">
-                        {{ analysis.performance_notes }}
-                    </div>
-                </div>
-            </div>
-        </div>
+    {% if context_analysis.columns_referenced %}
+    <div class="mt-4">
+      <h4 class="text-xs font-semibold uppercase text-indigo-700 mb-2">Columns referenced</h4>
+      <div class="flex flex-wrap gap-1">
+        {% for column in context_analysis.columns_referenced %}
+        <span class="px-2 py-0.5 bg-white rounded text-xs font-mono text-indigo-800 ring-1 ring-indigo-200">{{ column }}</span>
+        {% endfor %}
+      </div>
     </div>
     {% endif %}
 
-    <!-- Execution Plan -->
-    {% if execution_plan %}
-    <div class="flex flex-wrap gap-4">
-        <div class="col-12">
-            <div class="bg-white rounded-lg border border-gray-200">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold">
-                    <h5 class="mb-0">
-                        <i class="fas fa-route me-2"></i>
-                        Query Execution Plan
-                    </h5>
-                </div>
-                <div class="p-4">
-                    <div class="execution-plan">
-                        {% if execution_plan.format == 'json' %}
-                            {{ execution_plan.plan|pprint }}
-                        {% else %}
-                            {% for row in execution_plan.plan %}
-                                {{ row|join:" | " }}<br>
-                            {% endfor %}
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-        </div>
+    {% if context_analysis.schema_analysis %}
+    <div class="mt-4">
+      <h4 class="text-xs font-semibold uppercase text-indigo-700 mb-2">Schema analysis per table</h4>
+      <ul class="space-y-2 text-sm">
+        {% for tbl, info in context_analysis.schema_analysis.items %}
+        <li class="bg-white rounded-md p-3 ring-1 ring-indigo-100">
+          <p class="font-mono text-xs font-semibold text-gray-900">{{ tbl }}</p>
+          <p class="mt-1 text-xs text-gray-600">{{ info }}</p>
+        </li>
+        {% endfor %}
+      </ul>
     </div>
     {% endif %}
 
-    <!-- Action Buttons -->
-    <div class="action-buttons">
-        <div class="flex flex-wrap gap-4">
-            <div class="col-12 flex gap-2 justify-center flex-wrap">
-                <a href="{% url 'submit_feedback' analysis.id %}" class="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-md hover:bg-emerald-700">
-                    <i class="fas fa-comment me-2"></i>
-                    Provide Feedback
-                </a>
-                <a href="{% url 'query_with_context' %}" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">
-                    <i class="fas fa-plus me-2"></i>
-                    Analyze Another Query
-                </a>
-                <a href="{% url 'database_schema' %}" class="btn btn-outline-info">
-                    <i class="fas fa-min-w-full text-sm me-2"></i>
-                    View Schema
-                </a>
-                <a href="{% url 'query_history' %}" class="btn btn-outline-secondary">
-                    <i class="fas fa-history me-2"></i>
-                    Query History
-                </a>
-                <a href="{% url 'index' %}" class="btn btn-outline-secondary">
-                    <i class="fas fa-home me-2"></i>
-                    Main Menu
-                </a>
-            </div>
-        </div>
+    {% if context_analysis.recommendations %}
+    <div class="mt-4">
+      <h4 class="text-xs font-semibold uppercase text-indigo-700 mb-2">💡 Context-aware recommendations</h4>
+      <ul class="space-y-1.5 text-sm text-gray-700 list-disc pl-5">
+        {% for rec in context_analysis.recommendations %}<li>{{ rec }}</li>{% endfor %}
+      </ul>
     </div>
+    {% endif %}
+  </section>
+  {% endif %}
+
+  {% if analysis.issues_found %}
+  <section class="bg-white rounded-lg border border-gray-200 p-5">
+    <h3 class="text-base font-semibold text-gray-900 flex items-center gap-2"><span>🔍</span><span>Issues found</span></h3>
+    <ul class="mt-4 space-y-3">
+      {% for issue in analysis.issues_found %}
+      <li class="rounded-md border-l-4 p-3
+        {% if issue.severity == 'critical' %}border-red-500 bg-red-50
+        {% elif issue.severity == 'high' %}border-orange-500 bg-orange-50
+        {% elif issue.severity == 'medium' %}border-amber-500 bg-amber-50
+        {% else %}border-sky-500 bg-sky-50{% endif %}">
+        <div class="flex items-center justify-between gap-2">
+          <span class="text-sm font-semibold text-gray-900">{{ issue.type|title }}</span>
+          <span class="text-xs font-medium px-2 py-0.5 rounded
+            {% if issue.severity == 'critical' %}bg-red-100 text-red-700
+            {% elif issue.severity == 'high' %}bg-orange-100 text-orange-700
+            {% elif issue.severity == 'medium' %}bg-amber-100 text-amber-700
+            {% else %}bg-sky-100 text-sky-700{% endif %}">
+            {% if issue.severity == 'critical' %}🔴 Critical{% elif issue.severity == 'high' %}🟠 High{% elif issue.severity == 'medium' %}🟡 Medium{% else %}🔵 Low{% endif %}
+          </span>
+        </div>
+        <p class="mt-1 text-sm text-gray-700">{{ issue.description }}</p>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
+
+  {% if analysis.recommendations %}
+  <section class="bg-white rounded-lg border border-gray-200 p-5">
+    <h3 class="text-base font-semibold text-gray-900 flex items-center gap-2"><span>💡</span><span>Recommendations</span></h3>
+    <ul class="mt-4 space-y-3">
+      {% for rec in analysis.recommendations %}
+      <li class="rounded-md border border-gray-200 p-4">
+        <div class="flex items-center justify-between gap-2">
+          <span class="text-sm font-semibold text-gray-900">{{ rec.type|title }}</span>
+          <span class="text-xs font-medium px-2 py-0.5 rounded
+            {% if rec.priority == 'critical' %}bg-red-100 text-red-700
+            {% elif rec.priority == 'high' %}bg-orange-100 text-orange-700
+            {% elif rec.priority == 'medium' %}bg-amber-100 text-amber-700
+            {% else %}bg-indigo-100 text-indigo-700{% endif %}">
+            {% if rec.priority == 'critical' %}⚡ Critical{% elif rec.priority == 'high' %}🔥 High{% elif rec.priority == 'medium' %}📈 Medium{% else %}💡 Suggestion{% endif %}
+          </span>
+        </div>
+        <p class="mt-2 text-sm text-gray-700">{{ rec.description }}</p>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
+
+  {% if analysis.performance_notes %}
+  <section class="bg-white rounded-lg border border-gray-200 p-5">
+    <h3 class="text-base font-semibold text-gray-900 flex items-center gap-2"><span>📊</span><span>Performance notes</span></h3>
+    <p class="mt-2 text-sm text-gray-700 whitespace-pre-wrap">{{ analysis.performance_notes }}</p>
+  </section>
+  {% endif %}
+
+  {% if execution_plan %}
+  <section class="bg-white rounded-lg border border-gray-200 p-5">
+    <h3 class="text-base font-semibold text-gray-900 flex items-center gap-2"><span>📋</span><span>Execution plan</span></h3>
+    {% if execution_plan.format == 'json' %}
+    <pre class="mt-3 p-3 bg-gray-900 text-gray-100 rounded text-xs overflow-x-auto">{{ execution_plan.plan|pprint }}</pre>
+    {% else %}
+    <div class="mt-3 overflow-x-auto">
+      <table class="min-w-full text-xs font-mono">
+        <tbody class="divide-y divide-gray-100">
+          {% for row in execution_plan.plan %}
+          <tr><td class="px-2 py-1 align-top text-gray-500">{{ forloop.counter }}.</td><td class="px-2 py-1 text-gray-800">{{ row }}</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+  </section>
+  {% endif %}
+
+  <div class="flex flex-wrap gap-2 pt-2">
+    <a href="{% url 'submit_feedback' analysis.id %}" class="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-md hover:bg-emerald-700">💬 Provide feedback</a>
+    <a href="{% url 'grade_results' analysis.id %}" class="inline-flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50">View standard analysis</a>
+    <a href="{% url 'query_history' %}" class="inline-flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50">Query history</a>
+  </div>
 </div>
-
-<script>
-    // Add copy to clipboard functionality for SQL query
-    function addCopyButton() {
-        const sqlCode = document.querySelector('.sql-code');
-        if (sqlCode) {
-            const copyBtn = document.createElement('button');
-            copyBtn.className = 'btn text-xs px-2 py-1 btn-outline-secondary position-absolute';
-            copyBtn.style.top = '10px';
-            copyBtn.style.right = '10px';
-            copyBtn.innerHTML = '<i class="fas fa-copy"></i>';
-            copyBtn.title = 'Copy SQL Query';
-
-            copyBtn.onclick = function() {
-                navigator.clipboard.writeText(sqlCode.textContent);
-                copyBtn.innerHTML = '<i class="fas fa-check text-emerald-600"></i>';
-                setTimeout(() => {
-                    copyBtn.innerHTML = '<i class="fas fa-copy"></i>';
-                }, 2000);
-            };
-
-            sqlCode.parentElement.style.position = 'relative';
-            sqlCode.parentElement.appendChild(copyBtn);
-        }
-    }
-
-    // Initialize copy button when page loads
-    document.addEventListener('DOMContentLoaded', addCopyButton);
-</script>
 {% endblock %}

--- a/analyzer/templates/analyzer/database_analyze.html
+++ b/analyzer/templates/analyzer/database_analyze.html
@@ -1,238 +1,44 @@
 {% extends 'analyzer/base.html' %}
 {% load static %}
 
-{% block title %}Database Analysis - QueryGrade{% endblock %}
-
-
+{% block title %}Connect database · QueryGrade{% endblock %}
 
 {% block content %}
-<div class="max-w-7xl mx-auto px-4 mt-4">
-    <div class="row justify-center">
-        <div class="lg:w-66/100">
-            <div class="bg-white rounded-lg border border-gray-200">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold">
-                    <h4 class="mb-0">
-                        <i class="fas fa-database me-2"></i>
-                        Database Architecture Analysis
-                    </h4>
-                </div>
-                <div class="p-4">
-                    <div class="connection-info">
-                        <h6><i class="fas fa-info-circle me-2"></i>About Database Analysis</h6>
-                        <p class="mb-0">
-                            Connect to your database to perform comprehensive schema analysis,
-                            query optimization with context-aware recommendations, and identify
-                            performance improvement opportunities based on your actual database structure.
-                        </p>
-                    </div>
+<div class="max-w-3xl mx-auto space-y-6">
+  <header>
+    <h1 class="text-2xl font-bold text-gray-900">🗄️ Connect a database</h1>
+    <p class="mt-1 text-sm text-gray-500">Connect to your database to enable schema introspection and context-aware query analysis.</p>
+  </header>
 
-                    <div class="security-notice">
-                        <h6><i class="fas fa-shield-alt me-2"></i>Security Notice</h6>
-                        <p class="mb-0">
-                            <strong>Your database credentials are secure:</strong> Connection details are used only
-                            for read-only analysis during your session and are not stored permanently.
-                            We recommend using a read-only database user for maximum security.
-                        </p>
-                    </div>
+  <section class="bg-white rounded-lg border border-gray-200 p-6">
+    <form method="post" class="space-y-5">
+      {% csrf_token %}
 
-                    <form method="post">
-                        {% csrf_token %}
+      {% for field in form %}
+      <div>
+        <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ field.label }}{% if field.field.required %} <span class="text-red-600">*</span>{% endif %}</label>
+        <div class="mt-1">{{ field }}</div>
+        {% if field.help_text %}<p class="mt-1 text-xs text-gray-500">{{ field.help_text|safe }}</p>{% endif %}
+        {% if field.errors %}<p class="mt-1 text-xs text-red-600">{{ field.errors|join:", " }}</p>{% endif %}
+      </div>
+      {% endfor %}
 
-                        <!-- Database Engine Selection -->
-                        <div class="mb-4">
-                            <label for="{{ form.engine.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">{{ form.engine.label }}</label>
-                            {{ form.engine }}
-                            {% if form.engine.help_text %}
-                                <div class="help-text">{{ form.engine.help_text }}</div>
-                            {% endif %}
-                            {% if form.engine.errors %}
-                                <div class="text-red-600 mt-1">
-                                    {% for error in form.engine.errors %}{{ error }}{% endfor %}
-                                </div>
-                            {% endif %}
-                        </div>
+      {% if form.non_field_errors %}
+      <div class="rounded-md bg-red-50 border border-red-200 p-3 text-sm text-red-800">{{ form.non_field_errors|join:", " }}</div>
+      {% endif %}
 
-                        <!-- Database Name -->
-                        <div class="mb-4">
-                            <label for="{{ form.name.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">{{ form.name.label }}</label>
-                            {{ form.name }}
-                            {% if form.name.help_text %}
-                                <div class="help-text">{{ form.name.help_text }}</div>
-                            {% endif %}
-                            {% if form.name.errors %}
-                                <div class="text-red-600 mt-1">
-                                    {% for error in form.name.errors %}{{ error }}{% endfor %}
-                                </div>
-                            {% endif %}
-                        </div>
+      <div class="flex flex-wrap gap-2 pt-2 border-t border-gray-100">
+        <button type="submit" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">
+          🔌 Test & connect
+        </button>
+        <a href="{% url 'index' %}" class="inline-flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50">Cancel</a>
+      </div>
+    </form>
+  </section>
 
-                        <div class="flex flex-wrap gap-4">
-                            <!-- Host -->
-                            <div class="md:flex-1">
-                                <div class="mb-4">
-                                    <label for="{{ form.host.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">{{ form.host.label }}</label>
-                                    {{ form.host }}
-                                    {% if form.host.help_text %}
-                                        <div class="help-text">{{ form.host.help_text }}</div>
-                                    {% endif %}
-                                    {% if form.host.errors %}
-                                        <div class="text-red-600 mt-1">
-                                            {% for error in form.host.errors %}{{ error }}{% endfor %}
-                                        </div>
-                                    {% endif %}
-                                </div>
-                            </div>
-
-                            <!-- Port -->
-                            <div class="md:flex-1">
-                                <div class="mb-4">
-                                    <label for="{{ form.port.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">{{ form.port.label }}</label>
-                                    {{ form.port }}
-                                    {% if form.port.help_text %}
-                                        <div class="help-text">{{ form.port.help_text }}</div>
-                                    {% endif %}
-                                    {% if form.port.errors %}
-                                        <div class="text-red-600 mt-1">
-                                            {% for error in form.port.errors %}{{ error }}{% endfor %}
-                                        </div>
-                                    {% endif %}
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="flex flex-wrap gap-4">
-                            <!-- Username -->
-                            <div class="md:flex-1">
-                                <div class="mb-4">
-                                    <label for="{{ form.user.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">{{ form.user.label }}</label>
-                                    {{ form.user }}
-                                    {% if form.user.help_text %}
-                                        <div class="help-text">{{ form.user.help_text }}</div>
-                                    {% endif %}
-                                    {% if form.user.errors %}
-                                        <div class="text-red-600 mt-1">
-                                            {% for error in form.user.errors %}{{ error }}{% endfor %}
-                                        </div>
-                                    {% endif %}
-                                </div>
-                            </div>
-
-                            <!-- Password -->
-                            <div class="md:flex-1">
-                                <div class="mb-4">
-                                    <label for="{{ form.password.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">{{ form.password.label }}</label>
-                                    {{ form.password }}
-                                    {% if form.password.help_text %}
-                                        <div class="help-text">{{ form.password.help_text }}</div>
-                                    {% endif %}
-                                    {% if form.password.errors %}
-                                        <div class="text-red-600 mt-1">
-                                            {% for error in form.password.errors %}{{ error }}{% endfor %}
-                                        </div>
-                                    {% endif %}
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Schema (for PostgreSQL) -->
-                        <div class="mb-4" id="schema-field" style="display: none;">
-                            <label for="{{ form.schema.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">{{ form.schema.label }}</label>
-                            {{ form.schema }}
-                            {% if form.schema.help_text %}
-                                <div class="help-text">{{ form.schema.help_text }}</div>
-                            {% endif %}
-                            {% if form.schema.errors %}
-                                <div class="text-red-600 mt-1">
-                                    {% for error in form.schema.errors %}{{ error }}{% endfor %}
-                                </div>
-                            {% endif %}
-                        </div>
-
-                        <!-- Form Errors -->
-                        {% if form.non_field_errors %}
-                            <div class="rounded-md bg-red-50 border border-red-200 p-3 text-sm text-red-800">
-                                {% for error in form.non_field_errors %}{{ error }}{% endfor %}
-                            </div>
-                        {% endif %}
-
-                        <div class="d-grid gap-2 d-md-flex justify-content-md-end">
-                            <a href="{% url 'index' %}" class="btn btn-outline-secondary me-md-2">Cancel</a>
-                            <button type="submit" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">
-                                <i class="fas fa-plug me-2"></i>
-                                Connect & Analyze Database
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            </div>
-
-            <!-- Features Overview -->
-            <div class="bg-white rounded-lg border border-gray-200 mt-4">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold">
-                    <h5 class="mb-0">What You'll Get</h5>
-                </div>
-                <div class="p-4">
-                    <div class="flex flex-wrap gap-4">
-                        <div class="md:flex-1">
-                            <h6><i class="fas fa-min-w-full text-sm text-indigo-600 me-2"></i>Schema Analysis</h6>
-                            <ul class="list-unstyled ms-3">
-                                <li>• Table structure overview</li>
-                                <li>• Column types and constraints</li>
-                                <li>• Index analysis</li>
-                                <li>• Foreign key relationships</li>
-                            </ul>
-                        </div>
-                        <div class="md:flex-1">
-                            <h6><i class="fas fa-search text-emerald-600 me-2"></i>Context-Aware Query Analysis</h6>
-                            <ul class="list-unstyled ms-3">
-                                <li>• Schema-specific recommendations</li>
-                                <li>• Index usage optimization</li>
-                                <li>• Query execution plans</li>
-                                <li>• Performance insights</li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+  <section class="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-900">
+    <p class="font-semibold">🔒 Security note</p>
+    <p class="mt-1 text-amber-800">Credentials are used only to introspect schema and run EXPLAIN — they're stored in your session and not persisted to disk. Use a read-only DB user where possible.</p>
+  </section>
 </div>
-
-<script>
-    // Show/hide schema field based on database engine
-    document.getElementById('id_engine').addEventListener('change', function() {
-        const schemaField = document.getElementById('schema-field');
-        if (this.value === 'postgresql') {
-            schemaField.style.display = 'block';
-        } else {
-            schemaField.style.display = 'none';
-        }
-    });
-
-    // Auto-populate default ports
-    document.getElementById('id_engine').addEventListener('change', function() {
-        const portField = document.getElementById('id_port');
-        const hostField = document.getElementById('id_host');
-        const userField = document.getElementById('id_user');
-
-        switch(this.value) {
-            case 'mysql':
-                if (!portField.value) portField.value = '3306';
-                if (!hostField.value) hostField.value = 'localhost';
-                break;
-            case 'postgresql':
-                if (!portField.value) portField.value = '5432';
-                if (!hostField.value) hostField.value = 'localhost';
-                break;
-            case 'sqlite':
-                portField.value = '';
-                hostField.value = '';
-                userField.value = '';
-                break;
-        }
-    });
-
-    // Initial setup
-    document.getElementById('id_engine').dispatchEvent(new Event('change'));
-</script>
 {% endblock %}

--- a/analyzer/templates/analyzer/database_schema.html
+++ b/analyzer/templates/analyzer/database_schema.html
@@ -1,247 +1,139 @@
 {% extends 'analyzer/base.html' %}
 {% load static %}
 
-{% block title %}Database Schema Analysis - QueryGrade{% endblock %}
-
-
+{% block title %}Database schema · QueryGrade{% endblock %}
 
 {% block content %}
-<div class="max-w-7xl mx-auto px-4 mt-4">
-    <!-- Database Overview -->
-    <div class="flex flex-wrap gap-4">
-        <div class="col-12">
-            <div class="stats-bg-white rounded-lg border border-gray-200">
-                <div class="row items-center">
-                    <div class="md:flex-1">
-                        <h4 class="mb-1">
-                            <i class="fas fa-database me-2"></i>
-                            {{ db_config.name }} ({{ db_config.engine|title }})
-                        </h4>
-                        <p class="mb-0">Connected to {{ db_config.host }}{% if db_config.port %}:{{ db_config.port }}{% endif %}</p>
-                    </div>
-                    <div class="md:flex-1 text-md-end">
-                        <div class="row text-center">
-                            <div class="col-3">
-                                <h5 class="mb-0">{{ table_count }}</h5>
-                                <small>Tables</small>
-                            </div>
-                            <div class="col-3">
-                                <h5 class="mb-0">{{ total_columns }}</h5>
-                                <small>Columns</small>
-                            </div>
-                            <div class="col-3">
-                                <h5 class="mb-0">{{ total_indexes }}</h5>
-                                <small>Indexes</small>
-                            </div>
-                            <div class="col-3">
-                                <h5 class="mb-0">{{ total_foreign_keys }}</h5>
-                                <small>Foreign Keys</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+<div class="space-y-6">
+  <header class="flex flex-wrap items-center justify-between gap-3">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900">🗄️ Database schema</h1>
+      <p class="mt-1 text-sm text-gray-500">{{ db_config.engine|title }} · <span class="font-medium">{{ db_config.name }}</span></p>
     </div>
+    <div class="flex flex-wrap gap-2 text-sm">
+      <a href="{% url 'query_with_context' %}" class="inline-flex items-center gap-2 px-3 py-1.5 bg-indigo-600 text-white rounded hover:bg-indigo-700">⭐ Grade with context</a>
+      <a href="{% url 'database_analyze' %}" class="px-3 py-1.5 rounded border border-gray-300 text-gray-700 hover:bg-gray-50">Switch database</a>
+    </div>
+  </header>
 
-    <!-- Analysis Results -->
-    {% if schema_analysis %}
-    <div class="flex flex-wrap gap-4">
-        <div class="col-12">
-            <div class="bg-white rounded-lg border border-gray-200">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold">
-                    <h5 class="mb-0">
-                        <i class="fas fa-chart-line me-2"></i>
-                        Schema Analysis Results
-                    </h5>
-                </div>
-                <div class="p-4">
-                    <!-- Issues -->
-                    {% if schema_analysis.issues %}
-                        <h6><i class="fas fa-exclamation-triangle text-red-600 me-2"></i>Issues Found</h6>
-                        {% for issue in schema_analysis.issues %}
-                            <div class="issue">
-                                <i class="fas fa-times-circle me-2"></i>{{ issue }}
-                            </div>
-                        {% endfor %}
-                    {% endif %}
+  <section class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+    <div class="bg-white rounded-lg border border-gray-200 p-4 text-center">
+      <div class="text-2xl font-bold text-indigo-700">{{ table_count }}</div>
+      <div class="text-xs text-gray-500 mt-1">Tables</div>
+    </div>
+    <div class="bg-white rounded-lg border border-gray-200 p-4 text-center">
+      <div class="text-2xl font-bold text-indigo-700">{{ total_columns }}</div>
+      <div class="text-xs text-gray-500 mt-1">Columns</div>
+    </div>
+    <div class="bg-white rounded-lg border border-gray-200 p-4 text-center">
+      <div class="text-2xl font-bold text-indigo-700">{{ total_indexes }}</div>
+      <div class="text-xs text-gray-500 mt-1">Indexes</div>
+    </div>
+    <div class="bg-white rounded-lg border border-gray-200 p-4 text-center">
+      <div class="text-2xl font-bold text-indigo-700">{{ total_foreign_keys }}</div>
+      <div class="text-xs text-gray-500 mt-1">Foreign keys</div>
+    </div>
+  </section>
 
-                    <!-- Performance Notes -->
-                    {% if schema_analysis.performance_notes %}
-                        <h6><i class="fas fa-tachometer-alt text-info me-2"></i>Performance Considerations</h6>
-                        {% for note in schema_analysis.performance_notes %}
-                            <div class="performance-note">
-                                <i class="fas fa-info-circle me-2"></i>{{ note }}
-                            </div>
-                        {% endfor %}
-                    {% endif %}
+  {% if schema_analysis %}
+  <section class="bg-white rounded-lg border border-gray-200 p-5">
+    <h2 class="text-base font-semibold text-gray-900 flex items-center gap-2"><span>🔍</span><span>Schema analysis</span></h2>
 
-                    <!-- Recommendations -->
-                    {% if schema_analysis.recommendations %}
-                        <h6><i class="fas fa-lightbulb text-amber-600 me-2"></i>Recommendations</h6>
-                        {% for recommendation in schema_analysis.recommendations %}
-                            <div class="recommendation">
-                                <i class="fas fa-arrow-right me-2"></i>{{ recommendation }}
-                            </div>
-                        {% endfor %}
-                    {% endif %}
-
-                    {% if not schema_analysis.issues and not schema_analysis.performance_notes and not schema_analysis.recommendations %}
-                        <div class="rounded-md bg-green-50 border border-green-200 p-3 text-sm text-green-800">
-                            <i class="fas fa-check-circle me-2"></i>
-                            <strong>Great schema!</strong> No significant issues found. Your database schema follows good practices.
-                        </div>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
+    {% if schema_analysis.issues %}
+    <div class="mt-4">
+      <h3 class="text-sm font-semibold text-red-700">⚠ Issues</h3>
+      <ul class="mt-2 space-y-1.5 text-sm text-gray-700 list-disc pl-5">
+        {% for issue in schema_analysis.issues %}<li>{{ issue }}</li>{% endfor %}
+      </ul>
     </div>
     {% endif %}
 
-    <!-- Tables Overview -->
-    <div class="flex flex-wrap gap-4">
-        <div class="col-12">
-            <div class="bg-white rounded-lg border border-gray-200">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold flex justify-between items-center">
-                    <h5 class="mb-0">
-                        <i class="fas fa-min-w-full text-sm me-2"></i>
-                        Database Tables ({{ table_count }})
-                    </h5>
-                    <div>
-                        <button class="btn text-xs px-2 py-1 btn-outline-light" onclick="toggleAllTables()">
-                            <i class="fas fa-expand-arrows-alt me-1"></i>Toggle All
-                        </button>
-                    </div>
-                </div>
-                <div class="p-4">
-                    {% for min-w-full text-sm in tables %}
-                    <div class="min-w-full text-sm-bg-white rounded-lg border border-gray-200">
-                        <div class="min-w-full text-sm-header" data-bs-toggle="collapse" data-bs-target="#min-w-full text-sm-{{ forloop.counter }}" style="cursor: pointer;">
-                            <div class="row items-center">
-                                <div class="md:flex-1">
-                                    <h6 class="mb-0">
-                                        <i class="fas fa-min-w-full text-sm me-2"></i>{{ min-w-full text-sm.name }}
-                                    </h6>
-                                </div>
-                                <div class="md:flex-1">
-                                    <div class="min-w-full text-sm-stats text-right">
-                                        <span class="me-3">
-                                            <i class="fas fa-columns me-1"></i>{{ min-w-full text-sm.columns|length }} columns
-                                        </span>
-                                        <span class="me-3">
-                                            <i class="fas fa-search me-1"></i>{{ min-w-full text-sm.indexes|length }} indexes
-                                        </span>
-                                        {% if min-w-full text-sm.row_count %}
-                                            <span class="me-3">
-                                                <i class="fas fa-database me-1"></i>{{ min-w-full text-sm.row_count|floatformat:0 }} rows
-                                            </span>
-                                        {% endif %}
-                                        {% if min-w-full text-sm.size_mb %}
-                                            <span>
-                                                <i class="fas fa-hdd me-1"></i>{{ min-w-full text-sm.size_mb }} MB
-                                            </span>
-                                        {% endif %}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="collapse" id="min-w-full text-sm-{{ forloop.counter }}">
-                            <div class="min-w-full text-sm-content">
-                                <!-- Columns -->
-                                <div class="mb-3">
-                                    <h6><i class="fas fa-columns me-2"></i>Columns</h6>
-                                    {% for column in min-w-full text-sm.columns %}
-                                        <span class="column-badge">
-                                            {{ column.name }}
-                                            <small>({{ column.type }})</small>
-                                            {% if not column.nullable %}<i class="fas fa-exclamation-circle" title="NOT NULL"></i>{% endif %}
-                                        </span>
-                                    {% endfor %}
-                                </div>
-
-                                <!-- Indexes -->
-                                {% if min-w-full text-sm.indexes %}
-                                <div class="mb-3">
-                                    <h6><i class="fas fa-search me-2"></i>Indexes</h6>
-                                    {% for index in min-w-full text-sm.indexes %}
-                                        <span class="index-badge">
-                                            {{ index.name }}
-                                            <small>({{ index.columns|join:", " }})</small>
-                                            {% if index.unique %}<i class="fas fa-key" title="Unique"></i>{% endif %}
-                                            {% if index.primary %}<i class="fas fa-star" title="Primary Key"></i>{% endif %}
-                                        </span>
-                                    {% endfor %}
-                                </div>
-                                {% endif %}
-
-                                <!-- Foreign Keys -->
-                                {% if min-w-full text-sm.foreign_keys %}
-                                <div class="mb-3">
-                                    <h6><i class="fas fa-link me-2"></i>Foreign Keys</h6>
-                                    {% for fk in min-w-full text-sm.foreign_keys %}
-                                        <span class="fk-badge">
-                                            {{ fk.columns|join:", " }} → {{ fk.referenced_table }}.{{ fk.referenced_columns|join:", " }}
-                                        </span>
-                                    {% endfor %}
-                                </div>
-                                {% endif %}
-                            </div>
-                        </div>
-                    </div>
-                    {% empty %}
-                    <div class="rounded-md bg-indigo-50 border border-indigo-200 p-3 text-sm text-indigo-800">
-                        <i class="fas fa-info-circle me-2"></i>
-                        No tables found in this database.
-                    </div>
-                    {% endfor %}
-                </div>
-            </div>
-        </div>
+    {% if schema_analysis.performance_notes %}
+    <div class="mt-4">
+      <h3 class="text-sm font-semibold text-amber-700">⚡ Performance notes</h3>
+      <ul class="mt-2 space-y-1.5 text-sm text-gray-700 list-disc pl-5">
+        {% for note in schema_analysis.performance_notes %}<li>{{ note }}</li>{% endfor %}
+      </ul>
     </div>
+    {% endif %}
 
-    <!-- Action Buttons -->
-    <div class="action-buttons">
-        <div class="flex flex-wrap gap-4">
-            <div class="col-12 flex gap-2 justify-center">
-                <a href="{% url 'query_with_context' %}" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">
-                    <i class="fas fa-search me-2"></i>
-                    Analyze Query with Context
-                </a>
-                <a href="{% url 'database_analyze' %}" class="btn btn-outline-secondary">
-                    <i class="fas fa-sync me-2"></i>
-                    Connect Different Database
-                </a>
-                <a href="{% url 'index' %}" class="btn btn-outline-secondary">
-                    <i class="fas fa-home me-2"></i>
-                    Back to Main
-                </a>
-            </div>
-        </div>
+    {% if schema_analysis.recommendations %}
+    <div class="mt-4">
+      <h3 class="text-sm font-semibold text-emerald-700">💡 Recommendations</h3>
+      <ul class="mt-2 space-y-1.5 text-sm text-gray-700 list-disc pl-5">
+        {% for rec in schema_analysis.recommendations %}<li>{{ rec }}</li>{% endfor %}
+      </ul>
     </div>
+    {% endif %}
+
+    {% if not schema_analysis.issues and not schema_analysis.performance_notes and not schema_analysis.recommendations %}
+    <p class="mt-3 text-sm text-gray-500">No schema issues detected. Your structure looks good!</p>
+    {% endif %}
+  </section>
+  {% endif %}
+
+  <section class="space-y-3">
+    <h2 class="text-base font-semibold text-gray-900">Tables</h2>
+    {% for table in tables %}
+    <details class="bg-white rounded-lg border border-gray-200">
+      <summary class="cursor-pointer flex items-center justify-between gap-3 px-5 py-3 hover:bg-gray-50">
+        <div class="flex items-center gap-3 flex-1 min-w-0">
+          <span class="text-lg">📋</span>
+          <span class="font-mono text-sm font-semibold text-gray-900 truncate">{{ table.name }}</span>
+        </div>
+        <div class="flex flex-shrink-0 gap-3 text-xs text-gray-500">
+          <span>{{ table.columns|length }} cols</span>
+          <span>{{ table.indexes|length }} idx</span>
+          <span>{{ table.foreign_keys|length }} fks</span>
+        </div>
+      </summary>
+      <div class="px-5 pb-5 pt-2 space-y-4 border-t border-gray-100">
+        <div>
+          <h4 class="text-xs font-semibold uppercase text-gray-500 mb-2">Columns</h4>
+          <div class="flex flex-wrap gap-1">
+            {% for column in table.columns %}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 rounded text-xs font-mono">
+              <span class="font-semibold text-gray-900">{{ column.name }}</span>
+              <span class="text-gray-500">{{ column.type }}</span>
+              {% if not column.nullable %}<span title="NOT NULL" class="text-red-500">!</span>{% endif %}
+            </span>
+            {% endfor %}
+          </div>
+        </div>
+
+        {% if table.indexes %}
+        <div>
+          <h4 class="text-xs font-semibold uppercase text-gray-500 mb-2">Indexes</h4>
+          <div class="flex flex-wrap gap-1">
+            {% for index in table.indexes %}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-50 text-indigo-800 rounded text-xs font-mono">
+              <span class="font-semibold">{{ index.name }}</span>
+              <span class="text-indigo-600">({{ index.columns|join:", " }})</span>
+              {% if index.unique %}<span title="Unique" class="text-amber-600">🔑</span>{% endif %}
+              {% if index.primary %}<span title="Primary key" class="text-emerald-600">⭐</span>{% endif %}
+            </span>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
+
+        {% if table.foreign_keys %}
+        <div>
+          <h4 class="text-xs font-semibold uppercase text-gray-500 mb-2">Foreign keys</h4>
+          <ul class="space-y-1 text-xs font-mono text-gray-700">
+            {% for fk in table.foreign_keys %}
+            <li><span class="text-gray-500">{{ fk.columns|join:", " }}</span> → <span class="text-indigo-700">{{ fk.referenced_table }}.{{ fk.referenced_columns|join:", " }}</span></li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+      </div>
+    </details>
+    {% empty %}
+    <div class="bg-white rounded-lg border border-gray-200 p-8 text-center text-sm text-gray-500">
+      No tables found in this database.
+    </div>
+    {% endfor %}
+  </section>
 </div>
-
-<script>
-    function toggleAllTables() {
-        const collapseElements = document.querySelectorAll('[id^="min-w-full text-sm-"]');
-        let anyExpanded = false;
-
-        collapseElements.forEach(element => {
-            if (element.classList.contains('show')) {
-                anyExpanded = true;
-            }
-        });
-
-        collapseElements.forEach(element => {
-            const bsCollapse = new bootstrap.Collapse(element, {
-                toggle: false
-            });
-
-            if (anyExpanded) {
-                bsCollapse.hide();
-            } else {
-                bsCollapse.show();
-            }
-        });
-    }
-</script>
 {% endblock %}

--- a/analyzer/templates/analyzer/query_with_context.html
+++ b/analyzer/templates/analyzer/query_with_context.html
@@ -1,212 +1,59 @@
 {% extends 'analyzer/base.html' %}
 {% load static %}
 
-{% block title %}Context-Aware Query Analysis - QueryGrade{% endblock %}
-
-
+{% block title %}Grade with database context · QueryGrade{% endblock %}
 
 {% block content %}
-<div class="max-w-7xl mx-auto px-4 mt-4">
-    <div class="row justify-center">
-        <div class="lg:w-83/100">
-            <!-- Context Information -->
-            <div class="context-info">
-                <div class="row items-center">
-                    <div class="md:flex-1">
-                        <h4 class="mb-1">
-                            <i class="fas fa-link me-2"></i>
-                            Context-Aware Query Analysis
-                        </h4>
-                        <p class="mb-0">
-                            Connected to <strong>{{ db_config.name }}</strong>
-                            <span class="db-badge">{{ db_config.engine|title }}</span>
-                        </p>
-                    </div>
-                    <div class="md:flex-1 text-md-end">
-                        <a href="{% url 'database_schema' %}" class="btn btn-outline-light">
-                            <i class="fas fa-min-w-full text-sm me-2"></i>View Schema
-                        </a>
-                    </div>
-                </div>
-            </div>
+<div class="max-w-4xl mx-auto space-y-6">
+  <header>
+    <h1 class="text-2xl font-bold text-gray-900">⭐ Grade query with database context</h1>
+    <p class="mt-1 text-sm text-gray-500">Analyze a query against your live database schema for context-aware recommendations.</p>
+  </header>
 
-            <!-- Feature Highlights -->
-            <div class="row mb-4">
-                <div class="md:flex-1">
-                    <div class="feature-highlight">
-                        <h6><i class="fas fa-search text-emerald-600 me-2"></i>Schema-Aware Analysis</h6>
-                        <p class="mb-0 small">Recommendations based on your actual min-w-full text-sm structure, indexes, and relationships.</p>
-                    </div>
-                </div>
-                <div class="md:flex-1">
-                    <div class="feature-highlight">
-                        <h6><i class="fas fa-chart-line text-emerald-600 me-2"></i>Execution Plan</h6>
-                        <p class="mb-0 small">Real database execution plan analysis for performance insights.</p>
-                    </div>
-                </div>
-                <div class="md:flex-1">
-                    <div class="feature-highlight">
-                        <h6><i class="fas fa-lightbulb text-emerald-600 me-2"></i>Targeted Recommendations</h6>
-                        <p class="mb-0 small">Specific advice for your database configuration and data patterns.</p>
-                    </div>
-                </div>
-            </div>
+  {% if db_config %}
+  <div class="rounded-md bg-emerald-50 border border-emerald-200 p-3 text-sm text-emerald-900 flex items-center justify-between gap-3">
+    <span>✓ Connected to <strong>{{ db_config.name }}</strong></span>
+    <span class="inline-flex items-center px-2 py-0.5 rounded bg-emerald-100 text-emerald-700 text-xs font-medium">{{ db_config.engine|title }}</span>
+    <a href="{% url 'database_analyze' %}" class="text-xs text-emerald-800 hover:underline">Switch DB →</a>
+  </div>
+  {% endif %}
 
-            <!-- Query Input Form -->
-            <div class="bg-white rounded-lg border border-gray-200">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold">
-                    <h5 class="mb-0">
-                        <i class="fas fa-code me-2"></i>
-                        SQL Query Analysis
-                    </h5>
-                </div>
-                <div class="p-4">
-                    <form method="post">
-                        {% csrf_token %}
+  <section class="bg-white rounded-lg border border-gray-200 p-6">
+    <form method="post" class="space-y-5">
+      {% csrf_token %}
 
-                        <!-- SQL Query Input -->
-                        <div class="mb-4">
-                            <label for="{{ form.sql_query.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
-                                <strong>{{ form.sql_query.label }}</strong>
-                            </label>
-                            {{ form.sql_query }}
-                            {% if form.sql_query.help_text %}
-                                <div class="form-text">{{ form.sql_query.help_text }}</div>
-                            {% endif %}
-                            {% if form.sql_query.errors %}
-                                <div class="text-red-600 mt-1">
-                                    {% for error in form.sql_query.errors %}{{ error }}{% endfor %}
-                                </div>
-                            {% endif %}
-                        </div>
+      <div>
+        <label for="{{ form.sql_query.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ form.sql_query.label }} <span class="text-red-600">*</span></label>
+        <div class="mt-1">{{ form.sql_query }}</div>
+        {% if form.sql_query.help_text %}<p class="mt-1 text-xs text-gray-500">{{ form.sql_query.help_text }}</p>{% endif %}
+        {% if form.sql_query.errors %}<p class="mt-1 text-xs text-red-600">{{ form.sql_query.errors|join:", " }}</p>{% endif %}
+      </div>
 
-                        <div class="flex flex-wrap gap-4">
-                            <!-- Database Version -->
-                            <div class="md:flex-1">
-                                <div class="mb-4">
-                                    <label for="{{ form.database_version.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">{{ form.database_version.label }}</label>
-                                    {{ form.database_version }}
-                                    {% if form.database_version.help_text %}
-                                        <div class="form-text">{{ form.database_version.help_text }}</div>
-                                    {% endif %}
-                                    {% if form.database_version.errors %}
-                                        <div class="text-red-600 mt-1">
-                                            {% for error in form.database_version.errors %}{{ error }}{% endfor %}
-                                        </div>
-                                    {% endif %}
-                                </div>
-                            </div>
+      {% if form.database_version %}
+      <div>
+        <label for="{{ form.database_version.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ form.database_version.label }}</label>
+        <div class="mt-1">{{ form.database_version }}</div>
+        {% if form.database_version.help_text %}<p class="mt-1 text-xs text-gray-500">{{ form.database_version.help_text }}</p>{% endif %}
+      </div>
+      {% endif %}
 
-                            <!-- Database Type (read-only) -->
-                            <div class="md:flex-1">
-                                <div class="mb-4">
-                                    <label class="block text-sm font-medium text-gray-700 mb-1">Database Type</label>
-                                    <input type="text" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 text-sm" value="{{ db_config.engine|title }}" readonly>
-                                    <div class="form-text">Automatically detected from your connection</div>
-                                </div>
-                            </div>
-                        </div>
+      {% if form.use_case_notes %}
+      <div>
+        <label for="{{ form.use_case_notes.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ form.use_case_notes.label }}</label>
+        <div class="mt-1">{{ form.use_case_notes }}</div>
+        {% if form.use_case_notes.help_text %}<p class="mt-1 text-xs text-gray-500">{{ form.use_case_notes.help_text }}</p>{% endif %}
+      </div>
+      {% endif %}
 
-                        <!-- Use Case Notes -->
-                        <div class="mb-4">
-                            <label for="{{ form.use_case_notes.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">{{ form.use_case_notes.label }}</label>
-                            {{ form.use_case_notes }}
-                            {% if form.use_case_notes.help_text %}
-                                <div class="form-text">{{ form.use_case_notes.help_text }}</div>
-                            {% endif %}
-                            {% if form.use_case_notes.errors %}
-                                <div class="text-red-600 mt-1">
-                                    {% for error in form.use_case_notes.errors %}{{ error }}{% endfor %}
-                                </div>
-                            {% endif %}
-                        </div>
+      {{ form.database_type.as_hidden }}
 
-                        <!-- Form Errors -->
-                        {% if form.non_field_errors %}
-                            <div class="rounded-md bg-red-50 border border-red-200 p-3 text-sm text-red-800">
-                                {% for error in form.non_field_errors %}{{ error }}{% endfor %}
-                            </div>
-                        {% endif %}
-
-                        <!-- Submit Button -->
-                        <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-4">
-                            <a href="{% url 'database_schema' %}" class="btn btn-outline-secondary me-md-2">Back to Schema</a>
-                            <button type="submit" class="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-md hover:bg-emerald-700 btn-analyze">
-                                <i class="fas fa-magic me-2"></i>
-                                Analyze with Context
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            </div>
-
-            <!-- Tips -->
-            <div class="bg-white rounded-lg border border-gray-200 mt-4">
-                <div class="px-4 py-3 border-b border-gray-100 font-semibold">
-                    <h6 class="mb-0">
-                        <i class="fas fa-lightbulb me-2"></i>
-                        Tips for Better Analysis
-                    </h6>
-                </div>
-                <div class="p-4">
-                    <div class="flex flex-wrap gap-4">
-                        <div class="md:flex-1">
-                            <h6 class="text-indigo-600">Query Examples</h6>
-                            <ul class="list-unstyled">
-                                <li class="mb-2">
-                                    <i class="fas fa-check text-emerald-600 me-2"></i>
-                                    <code>SELECT u.name FROM users u WHERE u.active = 1</code>
-                                </li>
-                                <li class="mb-2">
-                                    <i class="fas fa-check text-emerald-600 me-2"></i>
-                                    <code>SELECT COUNT(*) FROM orders WHERE created_at >= '2023-01-01'</code>
-                                </li>
-                                <li>
-                                    <i class="fas fa-check text-emerald-600 me-2"></i>
-                                    Complex JOINs and subqueries
-                                </li>
-                            </ul>
-                        </div>
-                        <div class="md:flex-1">
-                            <h6 class="text-indigo-600">Context Benefits</h6>
-                            <ul class="list-unstyled">
-                                <li class="mb-2">
-                                    <i class="fas fa-arrow-right text-info me-2"></i>
-                                    Index usage recommendations
-                                </li>
-                                <li class="mb-2">
-                                    <i class="fas fa-arrow-right text-info me-2"></i>
-                                    Table size considerations
-                                </li>
-                                <li>
-                                    <i class="fas fa-arrow-right text-info me-2"></i>
-                                    Foreign key optimization
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+      <div class="flex flex-wrap gap-2 pt-2 border-t border-gray-100">
+        <button type="submit" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">
+          🔍 Analyze with context
+        </button>
+        <a href="{% url 'database_schema' %}" class="inline-flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50">View schema</a>
+      </div>
+    </form>
+  </section>
 </div>
-
-<script>
-    // Auto-resize textarea based on content
-    const textarea = document.getElementById('{{ form.sql_query.id_for_label }}');
-    if (textarea) {
-        textarea.addEventListener('input', function() {
-            this.style.height = 'auto';
-            this.style.height = Math.max(this.scrollHeight, 200) + 'px';
-        });
-
-        // Initial resize
-        textarea.style.height = Math.max(textarea.scrollHeight, 200) + 'px';
-    }
-
-    // Add syntax highlighting class
-    if (textarea) {
-        textarea.classList.add('sql-editor');
-    }
-</script>
 {% endblock %}


### PR DESCRIPTION
Closes #18. Refs #21.

4 templates restyled (975 → 428 total lines).

Includes a real bug fix in database_schema.html: the bulk-conversion pass had mangled the loop variable `table` into `min-w-full text-sm` (Bootstrap class collision), which would have crashed Django template rendering. Now uses `table` correctly.

Other notable changes:
- contextualized_results: gradient "Database context" panel showing tables_referenced / columns_referenced / per-table schema_analysis dict (mapping table name → notes string).
- database_analyze: form rendered generically via {% for field in form %} so it adapts to any DatabaseConnectionForm fields.
- query_with_context: database_type rendered as hidden field (auto-populated from session db_config).