### PR TITLE
UI: hand-tune batch_analysis & batch_results

### DIFF
--- a/analyzer/templates/analyzer/batch_analysis.html
+++ b/analyzer/templates/analyzer/batch_analysis.html
@@ -1,244 +1,83 @@
+{% extends 'analyzer/base.html' %}
 {% load static %}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>QueryGrade - Batch Query Analysis</title>
-    <link rel="stylesheet" href="{% static 'analyzer/css/styles.css' %}">
 
-    <!-- CodeMirror CSS -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/theme/material-darker.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/hint/show-hint.min.css">
+{% block title %}Batch analysis · QueryGrade{% endblock %}
 
+{% block content %}
+<div class="max-w-4xl mx-auto space-y-6">
+  <header>
+    <h1 class="text-2xl font-bold text-gray-900">📦 Batch query analysis</h1>
+    <p class="mt-1 text-sm text-gray-500">Submit multiple SQL queries at once for batch grading. Separate queries with semicolons or blank lines.</p>
+  </header>
 
-</head>
-<body>
-    <nav>
-        <h1>QueryGrade</h1>
-    </nav>
-    <div class="max-w-7xl mx-auto px-4">
+  <section class="bg-white rounded-lg border border-gray-200 p-6">
+    <form method="post" class="space-y-5">
+      {% csrf_token %}
 
-<div class="batch-container">
-    <div class="batch-header">
-        <h1>📊 Batch Query Analysis</h1>
-        <p class="subtitle">Analyze multiple SQL queries at once to identify patterns, common issues, and optimization opportunities</p>
+      <div>
+        <label for="{{ form.queries_text.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ form.queries_text.label }} <span class="text-red-600">*</span></label>
+        <div class="mt-1">{{ form.queries_text }}</div>
+        {% if form.queries_text.help_text %}<p class="mt-1 text-xs text-gray-500">{{ form.queries_text.help_text }}</p>{% endif %}
+        {% if form.queries_text.errors %}<p class="mt-1 text-xs text-red-600">{{ form.queries_text.errors|join:", " }}</p>{% endif %}
+      </div>
 
-        <div class="navigation-tabs">
-            <a href="{% url 'grade_query' %}" class="tab-link">Grade Query</a>
-            <a href="{% url 'index' %}" class="tab-link">Log Analysis</a>
-            <a href="{% url 'query_compare' %}" class="tab-link">Compare Queries</a>
-            <a href="{% url 'batch_analysis' %}" class="tab-link active">Batch Analysis</a>
-            <a href="{% url 'query_history' %}" class="tab-link">Query History</a>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label for="{{ form.database_type.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ form.database_type.label }}</label>
+          <div class="mt-1">{{ form.database_type }}</div>
+          {% if form.database_type.help_text %}<p class="mt-1 text-xs text-gray-500">{{ form.database_type.help_text }}</p>{% endif %}
         </div>
-    </div>
-
-    {% if messages %}
-        <div class="messages">
-            {% for message in messages %}
-                <div class="alert alert-{{ message.tags }}">
-                    {{ message }}
-                </div>
-            {% endfor %}
+        <div>
+          <label for="{{ form.database_version.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ form.database_version.label }}</label>
+          <div class="mt-1">{{ form.database_version }}</div>
+          {% if form.database_version.help_text %}<p class="mt-1 text-xs text-gray-500">{{ form.database_version.help_text }}</p>{% endif %}
         </div>
-    {% endif %}
+      </div>
 
-    <div class="feature-info">
-        <h4>🚀 Batch Analysis Features</h4>
-        <ul>
-            <li>Analyze up to 20 SQL queries simultaneously</li>
-            <li>Generate comprehensive statistics and grade distribution</li>
-            <li>Identify common issues across multiple queries</li>
-            <li>Compare performance and find best/worst performing queries</li>
-            <li>Export detailed results for documentation and reporting</li>
-        </ul>
-    </div>
+      <div>
+        <label for="{{ form.analysis_notes.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ form.analysis_notes.label }}</label>
+        <div class="mt-1">{{ form.analysis_notes }}</div>
+        {% if form.analysis_notes.help_text %}<p class="mt-1 text-xs text-gray-500">{{ form.analysis_notes.help_text }}</p>{% endif %}
+      </div>
 
-    <div class="batch-form-container">
-        <form method="post" class="batch-form">
-            {% csrf_token %}
+      {% if form.non_field_errors %}
+      <div class="rounded-md bg-red-50 border border-red-200 p-3 text-sm text-red-800">{{ form.non_field_errors|join:", " }}</div>
+      {% endif %}
 
-            <!-- SQL Queries Section -->
-            <div class="form-section">
-                <h3>📝 SQL Queries</h3>
+      <div class="flex flex-wrap gap-2 pt-2 border-t border-gray-100">
+        <button type="submit" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">
+          📊 Analyze batch
+        </button>
+        <button type="button" onclick="loadExample()" class="inline-flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50">📋 Load example</button>
+        <a href="{% url 'grade_query' %}" class="inline-flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50">Single query →</a>
+      </div>
+    </form>
+  </section>
 
-                <div class="mb-4">
-                    <label for="{{ form.queries_text.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
-                        {{ form.queries_text.label }} <span class="required">*</span>
-                    </label>
-                    {{ form.queries_text }}
-                    <div class="form-help">{{ form.queries_text.help_text }}</div>
-                </div>
-            </div>
-
-            <!-- Configuration Section -->
-            <div class="form-section">
-                <h3>⚙️ Analysis Configuration</h3>
-
-                <div class="form-row">
-                    <div class="half-width">
-                        <div class="mb-4">
-                            <label for="{{ form.database_type.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
-                                {{ form.database_type.label }}
-                            </label>
-                            {{ form.database_type }}
-                            <div class="form-help">{{ form.database_type.help_text }}</div>
-                        </div>
-                    </div>
-
-                    <div class="half-width">
-                        <div class="mb-4">
-                            <label for="{{ form.database_version.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
-                                {{ form.database_version.label }}
-                            </label>
-                            {{ form.database_version }}
-                            <div class="form-help">{{ form.database_version.help_text }}</div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="mb-4">
-                    <label for="{{ form.analysis_notes.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
-                        {{ form.analysis_notes.label }}
-                    </label>
-                    {{ form.analysis_notes }}
-                    <div class="form-help">{{ form.analysis_notes.help_text }}</div>
-                </div>
-            </div>
-
-            <div class="form-actions">
-                <button type="submit" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">
-                    <span>📊</span>
-                    Analyze Batch
-                </button>
-                <button type="button" class="inline-flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50" onclick="clearForm()">
-                    Clear All
-                </button>
-            </div>
-        </form>
-    </div>
+  <section class="bg-indigo-50 border border-indigo-200 rounded-lg p-4 text-sm text-indigo-900">
+    <p class="font-semibold">💡 Tip</p>
+    <p class="mt-1 text-indigo-800">Each query gets a separate grade and analysis. Use semicolons (<code class="font-mono bg-white px-1 rounded">;</code>) or blank lines to separate queries. The summary will rank them and surface common issues.</p>
+  </section>
 </div>
 
-    </div>
-
-<!-- CodeMirror JavaScript -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/sql/sql.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/hint/show-hint.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/hint/sql-hint.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/edit/matchbrackets.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/edit/closebrackets.min.js"></script>
-
 <script>
-let sqlEditor;
+function loadExample() {
+  const ta = document.getElementById('{{ form.queries_text.id_for_label }}');
+  if (!ta) return;
+  ta.value = `-- Query 1: SELECT *
+SELECT * FROM users WHERE active = 1;
 
-// Initialize CodeMirror SQL editor
-document.addEventListener('DOMContentLoaded', function() {
-    const textarea = document.querySelector('textarea.sql-editor');
+-- Query 2: Optimized version
+SELECT id, name, email FROM users WHERE active = 1 LIMIT 100;
 
-    if (textarea) {
-        // Create CodeMirror instance
-        sqlEditor = CodeMirror.fromTextArea(textarea, {
-            mode: 'text/x-sql',
-            theme: 'material-darker',
-            lineNumbers: true,
-            indentUnit: 2,
-            smartIndent: true,
-            lineWrapping: true,
-            autoCloseBrackets: true,
-            matchBrackets: true,
-            showCursorWhenSelecting: true,
-            extraKeys: {
-                "Ctrl-Space": "autocomplete",
-                "Cmd-Space": "autocomplete",
-                "F11": function(cm) {
-                    cm.setOption("fullScreen", !cm.getOption("fullScreen"));
-                },
-                "Esc": function(cm) {
-                    if (cm.getOption("fullScreen")) cm.setOption("fullScreen", false);
-                }
-            },
-            hintOptions: {
-                tables: {
-                    users: ["id", "name", "email", "created_at", "status", "last_login"],
-                    orders: ["id", "user_id", "total", "status", "created_at", "shipped_at"],
-                    products: ["id", "name", "price", "category", "in_stock", "description"],
-                    customers: ["id", "name", "email", "phone", "address", "registration_date"],
-                    employees: ["id", "name", "department", "salary", "hire_date", "manager_id"],
-                    categories: ["id", "name", "description", "parent_id"]
-                }
-            }
-        });
-
-        // Set editor height
-        sqlEditor.setSize(null, 400);
-
-        // Enable auto-completion
-        sqlEditor.on("inputRead", function(cm, event) {
-            if (event.text[0].match(/\w/) || event.text[0] === '.') {
-                cm.showHint();
-            }
-        });
-
-        // Sync with form submission
-        sqlEditor.on('change', function() {
-            sqlEditor.save(); // Save to original textarea
-        });
-    }
-});
-
-function clearForm() {
-    // Clear CodeMirror editor
-    if (sqlEditor) {
-        sqlEditor.setValue('');
-    }
-
-    // Clear regular form fields
-    document.querySelectorAll('input[type="text"], textarea:not(.sql-editor), select').forEach(field => {
-        field.value = '';
-        if (field.selectedIndex !== undefined) {
-            field.selectedIndex = 0;
-        }
-    });
-}
-
-// Load example queries for testing
-function loadBatchExample() {
-    if (sqlEditor) {
-        const exampleQueries = `SELECT * FROM users WHERE active = 1;
-
-SELECT COUNT(*) FROM orders WHERE status = 'pending';
-
-SELECT u.name, u.email, COUNT(o.id) as order_count
+-- Query 3: With proper joins
+SELECT u.id, u.name, COUNT(o.id) AS order_count
 FROM users u
 LEFT JOIN orders o ON u.id = o.user_id
-WHERE u.created_at >= '2023-01-01'
-GROUP BY u.id, u.name, u.email
+WHERE u.active = 1
+GROUP BY u.id, u.name
 ORDER BY order_count DESC
-LIMIT 10;
-
-SELECT p.name, p.price, c.name as category
-FROM products p
-JOIN categories c ON p.category_id = c.id
-WHERE p.in_stock > 0;
-
-SELECT AVG(total) as avg_order_value
-FROM orders
-WHERE created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY);`;
-
-        sqlEditor.setValue(exampleQueries);
-
-        // Set analysis notes
-        const notesTextarea = document.querySelector('textarea[id*="analysis_notes"]');
-        if (notesTextarea) {
-            notesTextarea.value = 'Sample batch analysis including basic selects, aggregations, joins, and analytics queries for testing purposes.';
-        }
-    }
+LIMIT 50;`;
 }
-
-// Add example button functionality
-console.log('Use loadBatchExample() to load example queries for batch analysis');
 </script>
-
-</body>
-</html>
+{% endblock %}

--- a/analyzer/templates/analyzer/batch_results.html
+++ b/analyzer/templates/analyzer/batch_results.html
@@ -1,306 +1,166 @@
+{% extends 'analyzer/base.html' %}
 {% load static %}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>QueryGrade - Batch Analysis Results</title>
-    <link rel="stylesheet" href="{% static 'analyzer/css/styles.css' %}">
 
-    <!-- CodeMirror CSS -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/theme/material-darker.min.css">
+{% block title %}Batch results · QueryGrade{% endblock %}
 
+{% block extra_head %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/theme/material-darker.min.css">
+<style>
+  .CodeMirror { height: auto; min-height: 100px; border-radius: 0.375rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
+</style>
+{% endblock %}
 
-</head>
-<body>
-    <nav>
-        <h1>QueryGrade</h1>
-    </nav>
-    <div class="max-w-7xl mx-auto px-4">
-
-<div class="batch-results-container">
-    <div class="batch-header">
-        <h1>📊 Batch Analysis Results</h1>
-        <p class="subtitle">Comprehensive analysis of {{ results|length }} SQL queries with performance insights and optimization recommendations</p>
-
-        <div class="navigation-tabs">
-            <a href="{% url 'grade_query' %}" class="tab-link">Grade Query</a>
-            <a href="{% url 'index' %}" class="tab-link">Log Analysis</a>
-            <a href="{% url 'query_compare' %}" class="tab-link">Compare Queries</a>
-            <a href="{% url 'batch_analysis' %}" class="tab-link active">Batch Analysis</a>
-            <a href="{% url 'query_history' %}" class="tab-link">Query History</a>
-        </div>
+{% block content %}
+<div class="space-y-6">
+  <header class="flex flex-wrap items-center justify-between gap-3">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900">📊 Batch results</h1>
+      <p class="mt-1 text-sm text-gray-500">{{ results|length }} {{ results|length|pluralize:"query,queries" }} analyzed.</p>
     </div>
+    <div class="flex flex-wrap gap-2 text-sm">
+      <a href="{% url 'batch_analysis' %}" class="px-3 py-1.5 rounded border border-gray-300 text-gray-700 hover:bg-gray-50">New batch</a>
+      {% if results %}<button onclick="exportResults()" class="px-3 py-1.5 rounded bg-emerald-600 text-white hover:bg-emerald-700">📥 Export</button>{% endif %}
+    </div>
+  </header>
 
-    {% if batch_summary %}
-    <div class="batch-overview">
-        <h2>🔍 Batch Analysis Overview</h2>
-        <div class="batch-summary">{{ batch_summary }}</div>
+  {% if batch_summary %}
+  <section class="bg-white rounded-lg border border-gray-200 p-5">
+    <h2 class="text-base font-semibold text-gray-900 flex items-center gap-2"><span>📋</span><span>Summary</span></h2>
+    <pre class="mt-3 text-sm text-gray-700 whitespace-pre-wrap font-sans">{{ batch_summary }}</pre>
+  </section>
+  {% endif %}
 
-        {% if batch_stats %}
-        <div class="batch-stats">
-            <div class="stat-bg-white rounded-lg border border-gray-200">
-                <h4>Total Queries</h4>
-                <div class="stat-value">{{ batch_stats.total_queries }}</div>
-            </div>
-            <div class="stat-bg-white rounded-lg border border-gray-200">
-                <h4>Average Grade</h4>
-                <div class="stat-value grade-{{ batch_stats.avg_grade|lower }}">{{ batch_stats.avg_grade }}</div>
-            </div>
-            <div class="stat-bg-white rounded-lg border border-gray-200">
-                <h4>Grade A Queries</h4>
-                <div class="stat-value grade-a">{{ batch_stats.grade_distribution.A|default:0 }}</div>
-            </div>
-            <div class="stat-bg-white rounded-lg border border-gray-200">
-                <h4>Needs Improvement</h4>
-                <div class="stat-value grade-f">{{ batch_stats.grade_distribution.F|default:0 }}</div>
-            </div>
+  {% if results %}
+  <section class="space-y-3">
+    {% for result in results %}
+    {% with grade=result.analysis.grade|lower %}
+    <article class="bg-white rounded-lg border border-gray-200 p-5">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-center gap-3 min-w-0">
+          <span class="text-xs font-mono text-gray-500">#{{ result.query_number }}</span>
+          {% if result.analysis %}
+          <span class="inline-flex items-center justify-center h-8 w-8 rounded-full text-sm font-bold flex-shrink-0
+            {% if grade == 'a' %}bg-emerald-100 text-emerald-700
+            {% elif grade == 'b' %}bg-lime-100 text-lime-700
+            {% elif grade == 'c' %}bg-amber-100 text-amber-700
+            {% elif grade == 'd' %}bg-orange-100 text-orange-700
+            {% else %}bg-red-100 text-red-700{% endif %}">{{ result.analysis.grade }}</span>
+          <span class="text-xs text-gray-600">{{ result.analysis.score|floatformat:1 }}/100</span>
+          {% elif result.error %}
+          <span class="inline-flex items-center px-2 py-0.5 rounded bg-red-100 text-red-700 text-xs font-medium">⚠ Error</span>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="mt-3">
+        <textarea class="sql-display">{{ result.query_text }}</textarea>
+      </div>
+
+      {% if result.error %}
+      <p class="mt-3 rounded bg-red-50 border border-red-200 p-3 text-sm text-red-800"><strong>Error:</strong> {{ result.error }}</p>
+      {% endif %}
+
+      {% if result.analysis %}
+      <div class="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
+        {% if result.analysis.issues_found %}
+        <div>
+          <h4 class="text-xs font-semibold uppercase text-gray-500 mb-1">Issues ({{ result.analysis.issues_found|length }})</h4>
+          <ul class="space-y-1 text-xs">
+            {% for issue in result.analysis.issues_found|slice:":4" %}
+            <li class="rounded border-l-2 px-2 py-1
+              {% if issue.severity == 'critical' %}border-red-500 bg-red-50
+              {% elif issue.severity == 'high' %}border-orange-500 bg-orange-50
+              {% elif issue.severity == 'medium' %}border-amber-500 bg-amber-50
+              {% else %}border-sky-500 bg-sky-50{% endif %}">
+              <span class="font-semibold text-gray-900">{{ issue.type|title }}</span>
+              <span class="text-gray-600">— {{ issue.description|truncatechars:80 }}</span>
+            </li>
+            {% endfor %}
+            {% if result.analysis.issues_found|length > 4 %}<li class="text-xs text-gray-400">+{{ result.analysis.issues_found|length|add:"-4" }} more</li>{% endif %}
+          </ul>
         </div>
         {% endif %}
-    </div>
-    {% endif %}
 
-    {% if results %}
-    <div class="queries-grid">
-        {% for result in results %}
-        <div class="query-result-bg-white rounded-lg border border-gray-200 {% if result.is_best %}best-query{% elif result.is_worst %}worst-query{% endif %}">
-            {% if result.is_best %}
-                <div class="performance-badge badge-best">Best Performing</div>
-            {% elif result.is_worst %}
-                <div class="performance-badge badge-worst">Needs Improvement</div>
-            {% endif %}
-
-            <div class="query-header">
-                <div class="query-title">Query {{ forloop.counter }}</div>
-                <div class="query-grade grade-{{ result.grade|lower }}-bg">{{ result.grade }}</div>
-            </div>
-
-            <div class="query-content">
-                <textarea class="sql-display">{{ result.query }}</textarea>
-            </div>
-
-            <div class="query-analysis">
-                {% if result.issues %}
-                <div class="analysis-section">
-                    <h4>⚠️ Issues Found</h4>
-                    <div class="issues-list">
-                        <ul>
-                            {% for issue in result.issues %}
-                            <li>{{ issue }}</li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                </div>
-                {% endif %}
-
-                {% if result.suggestions %}
-                <div class="analysis-section">
-                    <h4>💡 Optimization Suggestions</h4>
-                    <div class="suggestions-list">
-                        <ul>
-                            {% for suggestion in result.suggestions %}
-                            <li>{{ suggestion }}</li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                </div>
-                {% endif %}
-            </div>
+        {% if result.analysis.recommendations %}
+        <div>
+          <h4 class="text-xs font-semibold uppercase text-gray-500 mb-1">Recommendations ({{ result.analysis.recommendations|length }})</h4>
+          <ul class="space-y-1 text-xs">
+            {% for rec in result.analysis.recommendations|slice:":4" %}
+            <li class="rounded border border-gray-200 px-2 py-1">
+              <span class="font-semibold text-gray-900">{{ rec.type|title }}</span>
+              <span class="text-gray-600">— {{ rec.description|truncatechars:80 }}</span>
+            </li>
+            {% endfor %}
+            {% if result.analysis.recommendations|length > 4 %}<li class="text-xs text-gray-400">+{{ result.analysis.recommendations|length|add:"-4" }} more</li>{% endif %}
+          </ul>
         </div>
-        {% endfor %}
-    </div>
-    {% else %}
-    <div class="empty-state">
-        <h3>No Batch Results</h3>
-        <p>It looks like there was an issue processing your batch analysis. Please try again.</p>
-        <a href="{% url 'batch_analysis' %}" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">
-            <span>📊</span>
-            Start New Batch Analysis
-        </a>
-    </div>
-    {% endif %}
-
-    <div class="actions-bar">
-        <a href="{% url 'batch_analysis' %}" class="inline-flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50">
-            <span>🔄</span>
-            Analyze New Batch
-        </a>
-
-        {% if results %}
-        <button type="button" class="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-md hover:bg-emerald-700" onclick="exportBatchResults()">
-            <span>📥</span>
-            Export Results
-        </button>
         {% endif %}
-
-        <a href="{% url 'grade_query' %}" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">
-            <span>⭐</span>
-            Grade Single Query
-        </a>
-    </div>
+      </div>
+      {% endif %}
+    </article>
+    {% endwith %}
+    {% endfor %}
+  </section>
+  {% else %}
+  <section class="bg-white rounded-lg border border-gray-200 p-10 text-center">
+    <div class="text-4xl mb-3">📦</div>
+    <h2 class="text-lg font-semibold text-gray-900">No results</h2>
+    <p class="mt-2 text-sm text-gray-500">There was an issue processing your batch.</p>
+    <a href="{% url 'batch_analysis' %}" class="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">Start new batch</a>
+  </section>
+  {% endif %}
 </div>
 
-    </div>
-
-<!-- CodeMirror JavaScript -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/sql/sql.min.js"></script>
-
 <script>
-// Initialize CodeMirror for read-only SQL display
-document.addEventListener('DOMContentLoaded', function() {
-    const textareas = document.querySelectorAll('textarea.sql-display');
-
-    textareas.forEach((textarea) => {
-        if (textarea) {
-            const editor = CodeMirror.fromTextArea(textarea, {
-                mode: 'text/x-sql',
-                theme: 'material-darker',
-                lineNumbers: true,
-                readOnly: true,
-                lineWrapping: true,
-                showCursorWhenSelecting: false,
-                cursorBlinkRate: -1, // Hide cursor
-            });
-
-            // Set height based on content
-            const lineCount = textarea.value.split('\n').length;
-            const height = Math.max(100, Math.min(250, lineCount * 20 + 40));
-            editor.setSize(null, height);
-        }
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('textarea.sql-display').forEach(ta => {
+    const editor = CodeMirror.fromTextArea(ta, {
+      mode: 'text/x-sql', theme: 'material-darker',
+      lineNumbers: true, readOnly: true, lineWrapping: true,
+      cursorBlinkRate: -1,
     });
+    const lines = ta.value.split('\n').length;
+    editor.setSize(null, Math.max(100, Math.min(240, lines * 20 + 30)));
+  });
 });
 
-function exportBatchResults() {
-    {% if results %}
-    // Create comprehensive batch results export
-    const exportData = {
-        timestamp: new Date().toISOString(),
-        analysis_type: 'batch_analysis',
-        batch_summary: {{ batch_summary|escapejs }},
-        database_type: "{{ database_type|default:'Not specified' }}",
-        database_version: "{{ database_version|default:'Not specified' }}",
-        analysis_notes: "{{ analysis_notes|default:'None' }}",
-        total_queries: {{ results|length }},
-        {% if batch_stats %}
-        statistics: {
-            average_grade: "{{ batch_stats.avg_grade }}",
-            grade_distribution: {
-                {% for grade, count in batch_stats.grade_distribution.items %}
-                "{{ grade }}": {{ count }}{% if not forloop.last %},{% endif %}
-                {% endfor %}
-            }
-        },
-        {% endif %}
-        queries: [
-            {% for result in results %}
-            {
-                query_number: {{ forloop.counter }},
-                query: {{ result.query|escapejs }},
-                grade: "{{ result.grade }}",
-                score: {{ result.score|default:0 }},
-                issues: [
-                    {% for issue in result.issues %}
-                    {{ issue|escapejs }}{% if not forloop.last %},{% endif %}
-                    {% endfor %}
-                ],
-                suggestions: [
-                    {% for suggestion in result.suggestions %}
-                    {{ suggestion|escapejs }}{% if not forloop.last %},{% endif %}
-                    {% endfor %}
-                ],
-                is_best: {{ result.is_best|yesno:"true,false" }},
-                is_worst: {{ result.is_worst|yesno:"true,false" }}
-            }{% if not forloop.last %},{% endif %}
-            {% endfor %}
+function exportResults() {
+  const data = {
+    timestamp: new Date().toISOString(),
+    total_queries: {{ results|length }},
+    batch_summary: {{ batch_summary|default:''|escapejs|default:'""' }},
+    queries: [
+      {% for r in results %}
+      {
+        query_number: {{ r.query_number }},
+        query: "{{ r.query_text|escapejs }}",
+        grade: "{{ r.analysis.grade|default:'' }}",
+        score: {{ r.analysis.score|default:0|floatformat:2 }},
+        error: "{{ r.error|default:''|escapejs }}",
+        issues: [
+          {% for issue in r.analysis.issues_found %}
+          {type: "{{ issue.type|escapejs }}", severity: "{{ issue.severity|escapejs }}", description: "{{ issue.description|escapejs }}"}{% if not forloop.last %},{% endif %}
+          {% endfor %}
+        ],
+        recommendations: [
+          {% for rec in r.analysis.recommendations %}
+          {type: "{{ rec.type|escapejs }}", priority: "{{ rec.priority|escapejs }}", description: "{{ rec.description|escapejs }}"}{% if not forloop.last %},{% endif %}
+          {% endfor %}
         ]
-    };
-
-    // Create and download JSON file
-    const dataStr = JSON.stringify(exportData, null, 2);
-    const dataBlob = new Blob([dataStr], {type: 'application/json'});
-
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(dataBlob);
-    link.download = `batch-analysis-results-${new Date().toISOString().split('T')[0]}.json`;
-
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-
-    // Also create a text summary
-    let textSummary = "QueryGrade - Batch Analysis Results\n";
-    textSummary += "===================================\n\n";
-    textSummary += `Generated: ${new Date().toLocaleString()}\n`;
-    textSummary += `Database Type: {{ database_type|default:'Not specified' }}\n`;
-    textSummary += `Database Version: {{ database_version|default:'Not specified' }}\n`;
-    textSummary += `Total Queries Analyzed: {{ results|length }}\n\n`;
-
-    {% if batch_summary %}
-    textSummary += "Analysis Summary:\n";
-    textSummary += "{{ batch_summary|escapejs }}\n\n";
-    {% endif %}
-
-    {% if batch_stats %}
-    textSummary += "Grade Distribution:\n";
-    {% for grade, count in batch_stats.grade_distribution.items %}
-    textSummary += "{{ grade }}: {{ count }} queries\n";
-    {% endfor %}
-    textSummary += "\n";
-    {% endif %}
-
-    textSummary += "Individual Query Results:\n";
-    textSummary += "========================\n\n";
-
-    {% for result in results %}
-    textSummary += "Query {{ forloop.counter }}:\n";
-    textSummary += "Grade: {{ result.grade }}\n";
-    {% if result.is_best %}textSummary += "🏆 Best Performing Query\n";{% endif %}
-    {% if result.is_worst %}textSummary += "⚠️ Needs Most Improvement\n";{% endif %}
-    textSummary += "\nSQL Query:\n{{ result.query|escapejs }}\n\n";
-
-    {% if result.issues %}
-    textSummary += "Issues Found:\n";
-    {% for issue in result.issues %}
-    textSummary += "- {{ issue|escapejs }}\n";
-    {% endfor %}
-    textSummary += "\n";
-    {% endif %}
-
-    {% if result.suggestions %}
-    textSummary += "Optimization Suggestions:\n";
-    {% for suggestion in result.suggestions %}
-    textSummary += "- {{ suggestion|escapejs }}\n";
-    {% endfor %}
-    textSummary += "\n";
-    {% endif %}
-
-    textSummary += "----------------------------------------\n\n";
-    {% endfor %}
-
-    const textBlob = new Blob([textSummary], {type: 'text/plain'});
-    const textLink = document.createElement('a');
-    textLink.href = URL.createObjectURL(textBlob);
-    textLink.download = `batch-analysis-summary-${new Date().toISOString().split('T')[0]}.txt`;
-
-    document.body.appendChild(textLink);
-    textLink.click();
-    document.body.removeChild(textLink);
-
-    console.log('Batch analysis results exported successfully');
-    {% endif %}
+      }{% if not forloop.last %},{% endif %}
+      {% endfor %}
+    ]
+  };
+  const blob = new Blob([JSON.stringify(data, null, 2)], {type: 'application/json'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = `batch_results_${Date.now()}.json`;
+  document.body.appendChild(a); a.click(); a.remove();
+  URL.revokeObjectURL(url);
+  showToast('Results exported');
 }
-
-// Add keyboard shortcut for export
-document.addEventListener('keydown', function(e) {
-    if (e.ctrlKey && e.key === 's') {
-        e.preventDefault();
-        exportBatchResults();
-    }
-});
-
-console.log('Batch analysis results loaded. Press Ctrl+S to export results.');
 </script>
-
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
Closes #19. Refs #21.

- `batch_analysis.html`: 243 → 83. Was standalone HTML; now extends base. Form, load-example button, separator tip.
- `batch_results.html`: 305 → 166. Was standalone HTML; now extends base. Summary card, per-query article with grade pill, CodeMirror SQL, top-4 issue/rec columns. JSON export.
- **Bug fix in batch_results**: previous template referenced `result.grade` / `result.issues` / `result.suggestions` / `result.query` but the view passes `result.analysis.grade` / `result.analysis.issues_found` / `result.analysis.recommendations` / `result.query_text`. Corrected.