### PR TITLE
feat(ui): add CodeMirror syntax highlighting to result pages

### DIFF
--- a/analyzer/templates/analyzer/enhanced_grade_results.html
+++ b/analyzer/templates/analyzer/enhanced_grade_results.html
@@ -522,7 +522,7 @@
   async function copyRewriteSuggestions() {
     let s = "AI Query Rewrite Suggestions\n============================\n\n";
     document.querySelectorAll('[id^="rewrite-"]').forEach((el, i) => {
-      s += `${i + 1}. ${el.textContent.trim()}\n\n`;
+      s += `${i + 1}. ${(el.value || el.textContent || '').trim()}\n\n`;
     });
     await copyText(s, 'Rewrite suggestions copied');
   }
@@ -532,7 +532,8 @@
     r += `Overall Grade: {{ analysis.grade }} ({{ analysis.score|floatformat:1 }}/100)\n`;
     {% if ml_analysis.has_ml_analysis %}r += `AI Semantic Score: {{ ml_analysis.semantic_score|floatformat:1 }}/100\n`;{% endif %}
     r += '\n';
-    const q = document.getElementById('analyzed-query')?.textContent?.trim();
+    const analyzedEl = document.getElementById('analyzed-query');
+    const q = (analyzedEl?.value || analyzedEl?.textContent || '').trim();
     if (q) r += `Analyzed Query:\n---------------\n${q}\n\n`;
     document.querySelectorAll('.issue-item').forEach((issue, i) => {
       if (i === 0) r += "Issues Found:\n-------------\n";
@@ -564,7 +565,7 @@
       btn.classList.remove('text-gray-500', 'border-transparent');
       btn.classList.add('text-indigo-700', 'border-indigo-600');
     }
-    if (typeof sqlEditors !== 'undefined') sqlEditors.forEach(ed => ed.refresh());
+    if (typeof sqlEditors !== 'undefined') setTimeout(() => sqlEditors.forEach(ed => ed.refresh()), 0);
   }
 
   function toggleDetailedFeedback() {

--- a/analyzer/templates/analyzer/enhanced_grade_results.html
+++ b/analyzer/templates/analyzer/enhanced_grade_results.html
@@ -3,6 +3,14 @@
 
 {% block title %}Enhanced grade results · QueryGrade{% endblock %}
 
+{% block extra_head %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/theme/material-darker.min.css">
+<style>
+  .CodeMirror { height: auto; min-height: 80px; border-radius: 0.375rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="space-y-6">
 
@@ -263,7 +271,7 @@
       <h3 class="text-sm font-semibold text-gray-700">Analyzed query</h3>
       <button onclick="copyToClipboard('analyzed-query', 'Query copied!')" class="text-xs text-indigo-600 hover:underline">📋 Copy</button>
     </div>
-    <pre class="overflow-x-auto p-5 text-sm font-mono text-gray-100 bg-gray-900 rounded-b-lg"><code id="analyzed-query">{{ query.sql_text }}</code></pre>
+    <textarea class="sql-display" id="analyzed-query">{{ query.sql_text }}</textarea>
   </section>
 
   {% if analysis.issues_found %}
@@ -321,7 +329,7 @@
             <span class="text-xs font-semibold text-gray-500">Example</span>
             <button class="text-xs text-indigo-600 hover:underline" onclick="copyToClipboard('example-{{ forloop.counter }}', 'Example copied!')">📋 Copy</button>
           </div>
-          <pre class="text-xs font-mono p-3 bg-gray-900 text-gray-100 rounded overflow-x-auto"><code id="example-{{ forloop.counter }}">{{ rec.example }}</code></pre>
+          <textarea class="sql-display" id="example-{{ forloop.counter }}">{{ rec.example }}</textarea>
         </div>
         {% endif %}
       </li>
@@ -374,7 +382,7 @@
             <span class="text-xs font-semibold text-gray-500">Suggested query</span>
             <button class="text-xs text-indigo-600 hover:underline" onclick="copyToClipboard('rewrite-{{ forloop.counter }}', 'Rewritten query copied!')">📋 Copy</button>
           </div>
-          <pre class="text-xs font-mono p-3 bg-gray-900 text-gray-100 rounded overflow-x-auto"><code id="rewrite-{{ forloop.counter }}">{{ s.rewritten_query }}</code></pre>
+          <textarea class="sql-display" id="rewrite-{{ forloop.counter }}">{{ s.rewritten_query }}</textarea>
         </div>
         {% endif %}
         {% if s.estimated_improvement %}<p class="mt-2 text-xs text-emerald-700"><strong>Estimated improvement:</strong> {{ s.estimated_improvement }}%</p>{% endif %}
@@ -402,18 +410,20 @@
     </div>
 
     <div id="optimized-content" class="opt-tab-content mt-4">
-      <pre class="overflow-x-auto p-4 text-sm font-mono text-gray-100 bg-gray-900 rounded"><code id="optimized-query">{{ optimization_result.optimized_query }}</code></pre>
+      <textarea class="sql-display" id="optimized-query">{{ optimization_result.optimized_query }}</textarea>
     </div>
 
     <div id="comparison-content" class="opt-tab-content mt-4 hidden">
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <div>
           <h4 class="text-xs font-semibold uppercase text-gray-500 mb-1">Original</h4>
-          <pre class="overflow-x-auto p-3 text-xs font-mono text-gray-100 bg-gray-800 rounded"><code>{{ optimization_result.original_query }}</code></pre>
+          <textarea class="sql-display">{{ optimization_result.original_query }}</textarea>
         </div>
         <div>
           <h4 class="text-xs font-semibold uppercase text-gray-500 mb-1">Optimized</h4>
-          <pre class="overflow-x-auto p-3 text-xs font-mono text-gray-100 bg-gray-900 rounded ring-1 ring-emerald-500/40"><code>{{ optimization_result.optimized_query }}</code></pre>
+          <div class="ring-1 ring-emerald-500/40 rounded">
+            <textarea class="sql-display">{{ optimization_result.optimized_query }}</textarea>
+          </div>
         </div>
       </div>
       <p class="mt-2 text-xs text-emerald-700">+{{ optimization_result.improvement_estimate }}% estimated improvement</p>
@@ -471,6 +481,8 @@
   </div>
 </div>
 
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/sql/sql.min.js"></script>
 <script>
   async function copyText(text, msg) {
     try {
@@ -489,7 +501,8 @@
   async function copyToClipboard(elementId, msg) {
     const el = document.getElementById(elementId);
     if (!el) return;
-    await copyText((el.textContent || el.innerText).trim(), msg);
+    const text = (el.value !== undefined ? el.value : el.textContent || el.innerText || '').trim();
+    await copyText(text, msg);
   }
 
   async function copyAllRecommendations() {
@@ -551,6 +564,7 @@
       btn.classList.remove('text-gray-500', 'border-transparent');
       btn.classList.add('text-indigo-700', 'border-indigo-600');
     }
+    if (typeof sqlEditors !== 'undefined') sqlEditors.forEach(ed => ed.refresh());
   }
 
   function toggleDetailedFeedback() {
@@ -606,7 +620,19 @@
     }
   }
 
+  const sqlEditors = [];
   document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('textarea.sql-display').forEach(ta => {
+      const lines = ta.value.split('\n').length;
+      const ed = CodeMirror.fromTextArea(ta, {
+        mode: 'text/x-sql', theme: 'material-darker',
+        lineNumbers: true, readOnly: true, lineWrapping: true,
+        cursorBlinkRate: -1,
+      });
+      ed.setSize(null, Math.max(80, Math.min(500, lines * 20 + 40)));
+      sqlEditors.push(ed);
+    });
+
     const issues = {{ analysis.issues_found|safe }};
     const counts = {critical: 0, high: 0, medium: 0, low: 0};
     issues.forEach(i => { if (counts.hasOwnProperty(i.severity)) counts[i.severity]++; });

--- a/analyzer/templates/analyzer/grade_results.html
+++ b/analyzer/templates/analyzer/grade_results.html
@@ -3,6 +3,14 @@
 
 {% block title %}Grade results · QueryGrade{% endblock %}
 
+{% block extra_head %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/theme/material-darker.min.css">
+<style>
+  .CodeMirror { height: auto; min-height: 80px; border-radius: 0.375rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="space-y-6">
 
@@ -148,7 +156,7 @@
       <h3 class="text-sm font-semibold text-gray-700">Analyzed query</h3>
       <button onclick="copyToClipboard('analyzed-query', 'Query copied!')" class="text-xs text-indigo-600 hover:underline">📋 Copy</button>
     </div>
-    <pre class="overflow-x-auto p-5 text-sm font-mono text-gray-100 bg-gray-900 rounded-b-lg"><code id="analyzed-query">{{ query.sql_text }}</code></pre>
+    <textarea class="sql-display" id="analyzed-query">{{ query.sql_text }}</textarea>
   </section>
 
   {% if analysis.issues_found %}
@@ -204,7 +212,7 @@
             <span class="text-xs font-semibold text-gray-500">Example</span>
             <button class="text-xs text-indigo-600 hover:underline" onclick="copyToClipboard('example-{{ forloop.counter }}', 'Example copied!')">📋 Copy</button>
           </div>
-          <pre class="text-xs font-mono p-3 bg-gray-900 text-gray-100 rounded overflow-x-auto"><code id="example-{{ forloop.counter }}">{{ rec.example }}</code></pre>
+          <textarea class="sql-display" id="example-{{ forloop.counter }}">{{ rec.example }}</textarea>
         </div>
         {% endif %}
       </li>
@@ -231,18 +239,20 @@
     </div>
 
     <div id="optimized-content" class="opt-tab-content mt-4">
-      <pre class="overflow-x-auto p-4 text-sm font-mono text-gray-100 bg-gray-900 rounded"><code id="optimized-query">{{ optimization_result.optimized_query }}</code></pre>
+      <textarea class="sql-display" id="optimized-query">{{ optimization_result.optimized_query }}</textarea>
     </div>
 
     <div id="comparison-content" class="opt-tab-content mt-4 hidden">
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <div>
           <h4 class="text-xs font-semibold uppercase text-gray-500 mb-1">Original</h4>
-          <pre class="overflow-x-auto p-3 text-xs font-mono text-gray-100 bg-gray-800 rounded"><code>{{ optimization_result.original_query }}</code></pre>
+          <textarea class="sql-display">{{ optimization_result.original_query }}</textarea>
         </div>
         <div>
           <h4 class="text-xs font-semibold uppercase text-gray-500 mb-1">Optimized</h4>
-          <pre class="overflow-x-auto p-3 text-xs font-mono text-gray-100 bg-gray-900 rounded ring-1 ring-emerald-500/40"><code>{{ optimization_result.optimized_query }}</code></pre>
+          <div class="ring-1 ring-emerald-500/40 rounded">
+            <textarea class="sql-display">{{ optimization_result.optimized_query }}</textarea>
+          </div>
         </div>
       </div>
       <p class="mt-2 text-xs text-emerald-700">+{{ optimization_result.improvement_estimate }}% estimated improvement</p>
@@ -307,6 +317,8 @@
   </div>
 </div>
 
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/sql/sql.min.js"></script>
 <script>
   async function copyText(text, msg) {
     try {
@@ -332,7 +344,8 @@
   async function copyToClipboard(elementId, msg) {
     const el = document.getElementById(elementId);
     if (!el) return;
-    await copyText((el.textContent || el.innerText).trim(), msg);
+    const text = (el.value !== undefined ? el.value : el.textContent || el.innerText || '').trim();
+    await copyText(text, msg);
   }
 
   async function copyAllRecommendations() {
@@ -392,6 +405,7 @@
       btn.classList.remove('text-gray-500', 'border-transparent');
       btn.classList.add('text-indigo-700', 'border-indigo-600');
     }
+    if (typeof sqlEditors !== 'undefined') sqlEditors.forEach(ed => ed.refresh());
   }
 
   async function submitQuickFeedback(isHelpful) {
@@ -426,7 +440,19 @@
     status.classList.remove('hidden');
   }
 
+  const sqlEditors = [];
   document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('textarea.sql-display').forEach(ta => {
+      const lines = ta.value.split('\n').length;
+      const ed = CodeMirror.fromTextArea(ta, {
+        mode: 'text/x-sql', theme: 'material-darker',
+        lineNumbers: true, readOnly: true, lineWrapping: true,
+        cursorBlinkRate: -1,
+      });
+      ed.setSize(null, Math.max(80, Math.min(500, lines * 20 + 40)));
+      sqlEditors.push(ed);
+    });
+
     const issues = {{ analysis.issues_found|safe }};
     const counts = {critical: 0, high: 0, medium: 0, low: 0};
     issues.forEach(i => { if (counts.hasOwnProperty(i.severity)) counts[i.severity]++; });

--- a/analyzer/templates/analyzer/grade_results.html
+++ b/analyzer/templates/analyzer/grade_results.html
@@ -356,7 +356,8 @@
       const type = item.querySelector('.recommendation-type')?.textContent?.trim() || '';
       const priority = item.querySelector('.priority-badge')?.textContent?.trim() || '';
       const desc = item.querySelector('.recommendation-description')?.textContent?.trim() || '';
-      const example = item.querySelector('.recommendation-example code')?.textContent?.trim();
+      const exampleEl = item.querySelector('.recommendation-example textarea, .recommendation-example code');
+      const example = exampleEl ? (exampleEl.value || exampleEl.textContent || '').trim() : undefined;
       summary += `${i + 1}. ${type}\n   Priority: ${priority}\n   ${desc}\n`;
       if (example) summary += `   Example: ${example}\n`;
       summary += '\n';
@@ -370,7 +371,8 @@
     const grade = "{{ analysis.grade }}";
     const score = "{{ analysis.score|floatformat:1 }}";
     r += `Overall Grade: ${grade} (${score}/100)\n\n`;
-    const q = document.getElementById('analyzed-query')?.textContent?.trim();
+    const analyzedEl = document.getElementById('analyzed-query');
+    const q = (analyzedEl?.value || analyzedEl?.textContent || '').trim();
     if (q) r += `Analyzed Query:\n---------------\n${q}\n\n`;
     const issues = document.querySelectorAll('.issue-item');
     if (issues.length) {
@@ -405,7 +407,7 @@
       btn.classList.remove('text-gray-500', 'border-transparent');
       btn.classList.add('text-indigo-700', 'border-indigo-600');
     }
-    if (typeof sqlEditors !== 'undefined') sqlEditors.forEach(ed => ed.refresh());
+    if (typeof sqlEditors !== 'undefined') setTimeout(() => sqlEditors.forEach(ed => ed.refresh()), 0);
   }
 
   async function submitQuickFeedback(isHelpful) {


### PR DESCRIPTION
## Summary

- Replaces plain `<pre><code>` SQL blocks in `grade_results.html` and `enhanced_grade_results.html` with read-only CodeMirror editors (material-darker theme, line numbers)
- Matches the pattern already used in `compare_results.html` and `batch_results.html`
- Covers all SQL display locations: analyzed query, recommendation examples, AI rewrite suggestions, optimized query tab, and side-by-side comparison tab

## Changes

- Adds `{% block extra_head %}` with CodeMirror CSS (codemirror + material-darker) to both templates
- Converts all `<pre><code>` SQL blocks to `<textarea class="sql-display">` initialized as read-only CodeMirror editors
- Editors sized dynamically by line count (80–500px range)
- Fixes `copyToClipboard` to read `el.value` from the hidden textarea (CodeMirror wraps and hides the original element but its `.value` remains intact)
- Calls `editor.refresh()` on tab switch so side-by-side comparison editors render correctly after being unhidden

## Test plan

- [ ] Grade a complex multi-line SQL query → "Analyzed query" section shows syntax highlighting with line numbers
- [ ] Verify recommendation examples render as highlighted SQL editors
- [ ] If optimization result present: "Optimized" tab shows highlighted editor
- [ ] Switch to "Side-by-side" tab — both Original and Optimized panels render correctly
- [ ] Click Copy buttons on each panel — confirm copied text is plain SQL (not empty)
- [ ] Repeat on enhanced results page (`/grade/results/<id>/` with ML analysis)