### PR TITLE
feat(grade): autopopulate database version typeahead from db_type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -538,6 +538,7 @@ class SecurityAnalyzer(BaseAnalyzer):
 - Read-only SQL display: use `<textarea class="sql-display">` converted by CodeMirror (readOnly, material-darker). See `compare_results.html` / `batch_results.html` for the pattern. Never use `<pre><code>` for SQL display.
 - Copy functions (`copyFullReport`, `copyAllRecommendations`, `copyRewriteSuggestions`) read from DOM elements — use `el.value || el.textContent` for textareas, `el.textContent` for code/span. When changing element types, audit all copy functions.
 - CodeMirror in hidden tabs: always call `refresh()` inside `setTimeout(0)` after unhiding, so the browser repaints before CodeMirror remeasures.
+- Typeahead inputs that must preserve free-form entry: use `<datalist>` (not a `<select>` swap). Centralize option data in a Python module (e.g. `analyzer/db_versions.py`) and pass the dict directly to the template via `{{ var|json_script:"id" }}` + `JSON.parse(document.getElementById('id').textContent)`. Wire a `change` listener on the source `<select>` to rebuild `<datalist>` options and toggle the `list` attribute. See the `database_type` → `database_version` integration in `grade_form.html`.
 
 ## Known Issues
 
@@ -561,7 +562,7 @@ class SecurityAnalyzer(BaseAnalyzer):
 - Anonymous visitors may grade up to `ANON_TRIAL_CAP` (default 3, env-configurable) queries per session. Cap/count/remaining are computed by `anon_trial_state(request)` in `analyzer/views/utils.py` — import from there, do not duplicate inline.
 - Anonymous results are tracked in `session[ANON_ANALYSIS_SESSION_KEY]` (list of `analysis.id` ints). Access check in `grade_results`: `analysis_id not in session[ANON_ANALYSIS_SESSION_KEY]` — IDs are stored and compared as integers.
 - All `grade_form.html` render paths must include `trial_exhausted` in context (the template gates the entire `<form>` on it). Missing it renders the form even for exhausted anon users.
-- `grade_query()` has **4 render paths**: exhausted-trial early return, ValueError catch, generic Exception catch, and the bottom GET/failed-validation render. Any new context var (e.g. `db_versions_json`) must be added to all paths the form actually renders in.
+- `grade_query()` has **4 render paths**: exhausted-trial early return, ValueError catch, generic Exception catch, and the bottom GET/failed-validation render. Any new context var (e.g. `db_versions`) must be added to all paths the form actually renders in.
 - JS that references `#gradeForm` must guard with `const f = document.getElementById('gradeForm'); if (f) { ... }` — the element is absent when `trial_exhausted` is true.
 - Rate-limit stacking: use a callable key (`_anon_ip_key`) that returns `None` for authenticated users so the IP-keyed anon limit doesn't accidentally cap auth users on shared/NAT IPs. `django-ratelimit` skips the check when the key function returns `None`.
 

--- a/analyzer/db_versions.py
+++ b/analyzer/db_versions.py
@@ -1,0 +1,59 @@
+"""
+Curated database version lists for the grade form version datalist.
+
+Each entry is a (value, label) tuple. Values are submitted as database_version.
+Labels include EOL notes where relevant so users know what they're running.
+Ordered newest-first within each database.
+"""
+
+DATABASE_VERSIONS = {
+    'mysql': [
+        ('9.1',  'MySQL 9.1 (Innovation)'),
+        ('9.0',  'MySQL 9.0 (Innovation)'),
+        ('8.4',  'MySQL 8.4 LTS'),
+        ('8.3',  'MySQL 8.3'),
+        ('8.2',  'MySQL 8.2'),
+        ('8.1',  'MySQL 8.1'),
+        ('8.0',  'MySQL 8.0 LTS (EOL Apr 2026)'),
+        ('5.7',  'MySQL 5.7 (EOL Oct 2023)'),
+        ('5.6',  'MySQL 5.6 (EOL Feb 2021)'),
+        ('5.5',  'MySQL 5.5 (EOL Dec 2018)'),
+    ],
+    'postgresql': [
+        ('17',   'PostgreSQL 17'),
+        ('16',   'PostgreSQL 16'),
+        ('15',   'PostgreSQL 15'),
+        ('14',   'PostgreSQL 14'),
+        ('13',   'PostgreSQL 13'),
+        ('12',   'PostgreSQL 12'),
+        ('11',   'PostgreSQL 11 (EOL Nov 2023)'),
+        ('10',   'PostgreSQL 10 (EOL Nov 2022)'),
+        ('9.6',  'PostgreSQL 9.6 (EOL Nov 2021)'),
+    ],
+    'sqlite': [
+        ('3.47', 'SQLite 3.47 (2024)'),
+        ('3.45', 'SQLite 3.45 (2024)'),
+        ('3.43', 'SQLite 3.43 (2023)'),
+        ('3.40', 'SQLite 3.40 (2022)'),
+        ('3.37', 'SQLite 3.37 (2021)'),
+        ('3.35', 'SQLite 3.35 (2021)'),
+        ('3.31', 'SQLite 3.31 (2020)'),
+    ],
+    'oracle': [
+        ('23c',      'Oracle 23c'),
+        ('21c',      'Oracle 21c'),
+        ('19c',      'Oracle 19c LTS'),
+        ('18c',      'Oracle 18c'),
+        ('12c',      'Oracle 12c'),
+        ('11g',      'Oracle 11g (EOL Dec 2020)'),
+    ],
+    'sqlserver': [
+        ('2022',    'SQL Server 2022'),
+        ('2019',    'SQL Server 2019'),
+        ('2017',    'SQL Server 2017'),
+        ('2016',    'SQL Server 2016'),
+        ('2014',    'SQL Server 2014 (EOL Jul 2024)'),
+        ('2012',    'SQL Server 2012 (EOL Jul 2022)'),
+        ('2008 R2', 'SQL Server 2008 R2 (EOL Jul 2019)'),
+    ],
+}

--- a/analyzer/templates/analyzer/grade_form.html
+++ b/analyzer/templates/analyzer/grade_form.html
@@ -271,10 +271,12 @@ WHERE u.created_at > '2024-01-01' AND o.total > 100;</code></pre>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/fold/foldgutter.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/fold/brace-fold.min.js"></script>
 
+{{ db_versions|json_script:"db-versions-data" }}
 <script>
 let sqlEditor = null;
 
-const DB_VERSIONS = {{ db_versions_json|default:"{}"|safe }};
+const _dbVersionsEl = document.getElementById('db-versions-data');
+const DB_VERSIONS = _dbVersionsEl ? JSON.parse(_dbVersionsEl.textContent) : {};
 
 function updateVersionList(dbType) {
   const versionInput = document.getElementById('{{ form.database_version.id_for_label }}');

--- a/analyzer/templates/analyzer/grade_form.html
+++ b/analyzer/templates/analyzer/grade_form.html
@@ -160,11 +160,12 @@
         <div class="mt-1">{{ form.database_type }}</div>
         {% if form.database_type.help_text %}<p class="mt-1 text-xs text-gray-500">{{ form.database_type.help_text }}</p>{% endif %}
       </div>
-      <div>
+      <div id="db-version-wrapper">
         <label for="{{ form.database_version.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ form.database_version.label }}</label>
         <div class="mt-1">{{ form.database_version }}</div>
         {% if form.database_version.help_text %}<p class="mt-1 text-xs text-gray-500">{{ form.database_version.help_text }}</p>{% endif %}
       </div>
+      <datalist id="db-version-list"></datalist>
     </div>
 
     <div>
@@ -273,6 +274,31 @@ WHERE u.created_at > '2024-01-01' AND o.total > 100;</code></pre>
 <script>
 let sqlEditor = null;
 
+const DB_VERSIONS = {{ db_versions_json|default:"{}"|safe }};
+
+function updateVersionList(dbType) {
+  const versionInput = document.getElementById('{{ form.database_version.id_for_label }}');
+  const datalist = document.getElementById('db-version-list');
+  if (!versionInput || !datalist) return;
+
+  datalist.innerHTML = '';
+  const versions = DB_VERSIONS[dbType] || [];
+  versions.forEach(([value, label]) => {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.label = label;
+    datalist.appendChild(opt);
+  });
+
+  if (versions.length) {
+    versionInput.setAttribute('list', 'db-version-list');
+    versionInput.placeholder = 'Select or type a version…';
+  } else {
+    versionInput.removeAttribute('list');
+    versionInput.placeholder = 'e.g., 8.0, 13.4, etc.';
+  }
+}
+
 function toggleHistoryPanel() {
   const panel = document.getElementById('history-panel');
   const btn = document.getElementById('load-history-btn');
@@ -284,7 +310,10 @@ function loadFromHistory(btn) {
   // Populate form fields from data attributes
   if (sqlEditor) sqlEditor.setValue(btn.dataset.sql || '');
   const dbType = document.getElementById('{{ form.database_type.id_for_label }}');
-  if (dbType) dbType.value = btn.dataset.dbType || '';
+  if (dbType) {
+    dbType.value = btn.dataset.dbType || '';
+    updateVersionList(dbType.value);
+  }
   const dbVersion = document.getElementById('{{ form.database_version.id_for_label }}');
   if (dbVersion) dbVersion.value = btn.dataset.dbVersion || '';
   const useCase = document.getElementById('{{ form.use_case_notes.id_for_label }}');
@@ -313,6 +342,13 @@ document.addEventListener('click', e => {
 });
 
 document.addEventListener('DOMContentLoaded', () => {
+  const dbTypeSelect = document.getElementById('{{ form.database_type.id_for_label }}');
+  if (dbTypeSelect) {
+    dbTypeSelect.addEventListener('change', () => updateVersionList(dbTypeSelect.value));
+    // Restore datalist if page reloaded with a pre-selected db type (e.g., after form error)
+    if (dbTypeSelect.value) updateVersionList(dbTypeSelect.value);
+  }
+
   const ta = document.getElementById('{{ form.sql_query.id_for_label }}');
   if (ta) {
     sqlEditor = CodeMirror.fromTextArea(ta, {
@@ -359,6 +395,7 @@ function clearForm() {
   if (dt) dt.selectedIndex = 0;
   if (dv) dv.value = '';
   if (un) un.value = '';
+  updateVersionList('');
 }
 
 const EXAMPLES = {

--- a/analyzer/views/query_grading_views.py
+++ b/analyzer/views/query_grading_views.py
@@ -9,6 +9,7 @@ This module handles the core query grading functionality including:
 - Batch analysis
 """
 import asyncio
+import json
 import logging
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib import messages
@@ -19,6 +20,7 @@ from django_ratelimit.decorators import ratelimit
 from django.conf import settings
 
 from ..forms import QueryGradeForm, QueryCompareForm, BatchQueryForm
+from ..db_versions import DATABASE_VERSIONS
 from ..models import Query, QueryAnalysis, UserQueryHistory
 from ..query_analyzer import analyze_query
 from ..query_optimizer import optimize_query_from_analysis
@@ -161,6 +163,7 @@ def grade_query(request):
                     'trial_exhausted': is_anon and remaining <= 0,
                     'trial_cap': cap,
                     'trial_remaining': remaining,
+                    'db_versions_json': json.dumps(DATABASE_VERSIONS),
                 })
             except Exception as e:
                 who = 'anonymous' if is_anon else request.user.username
@@ -173,6 +176,7 @@ def grade_query(request):
                     'trial_exhausted': is_anon and remaining <= 0,
                     'trial_cap': cap,
                     'trial_remaining': remaining,
+                    'db_versions_json': json.dumps(DATABASE_VERSIONS),
                 })
         else:
             messages.error(request, "Please correct the errors in the form below.")
@@ -193,6 +197,7 @@ def grade_query(request):
         'trial_exhausted': is_anon and remaining <= 0,
         'trial_cap': cap,
         'trial_remaining': remaining,
+        'db_versions_json': json.dumps(DATABASE_VERSIONS),
     })
 
 

--- a/analyzer/views/query_grading_views.py
+++ b/analyzer/views/query_grading_views.py
@@ -9,7 +9,6 @@ This module handles the core query grading functionality including:
 - Batch analysis
 """
 import asyncio
-import json
 import logging
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib import messages
@@ -69,6 +68,7 @@ def grade_query(request):
                 'trial_exhausted': True,
                 'trial_cap': cap,
                 'trial_remaining': 0,
+                'db_versions': DATABASE_VERSIONS,
             })
 
         form = QueryGradeForm(request.POST)
@@ -163,7 +163,7 @@ def grade_query(request):
                     'trial_exhausted': is_anon and remaining <= 0,
                     'trial_cap': cap,
                     'trial_remaining': remaining,
-                    'db_versions_json': json.dumps(DATABASE_VERSIONS),
+                    'db_versions': DATABASE_VERSIONS,
                 })
             except Exception as e:
                 who = 'anonymous' if is_anon else request.user.username
@@ -176,7 +176,7 @@ def grade_query(request):
                     'trial_exhausted': is_anon and remaining <= 0,
                     'trial_cap': cap,
                     'trial_remaining': remaining,
-                    'db_versions_json': json.dumps(DATABASE_VERSIONS),
+                    'db_versions': DATABASE_VERSIONS,
                 })
         else:
             messages.error(request, "Please correct the errors in the form below.")
@@ -197,7 +197,7 @@ def grade_query(request):
         'trial_exhausted': is_anon and remaining <= 0,
         'trial_cap': cap,
         'trial_remaining': remaining,
-        'db_versions_json': json.dumps(DATABASE_VERSIONS),
+        'db_versions': DATABASE_VERSIONS,
     })
 
 


### PR DESCRIPTION
## Summary
- Curated `(value, label)` version lists per database engine in new `analyzer/db_versions.py` (newest first, EOL annotated).
- `grade_query` passes `db_versions_json` to all three form-render paths (initial GET, ValueError catch, generic Exception catch).
- `grade_form.html` adds a `<datalist>` and JS that rebuilds options on `database_type` change; `loadFromHistory` + `clearForm` updated to keep the typeahead in sync.
- Uses `<datalist>` (not a `<select>`) so unusual patch versions like `8.0.32` still submit.
- Closes the in-progress plan at `.claude/plans/2026-04-30_db-version-autopopulate.md`.

## Test plan
- [ ] `/grade/` (logged in) — selecting MySQL shows MySQL versions in the typeahead, including "MySQL 5.5 (EOL Dec 2018)"
- [ ] Switching to PostgreSQL immediately swaps the option list
- [ ] Selecting "Select Database (Optional)" clears the list; the version input still accepts free text
- [ ] Typing a custom value like "8.0.32" submits and grades fine
- [ ] Grade a query with MySQL 8.0 → reload → "Load from history" pre-fills both fields correctly
- [ ] Clear button empties the version input and removes the datalist binding
- [ ] Anonymous visitor (no history button) — form still works, typeahead populates