### PR TITLE
chore(lint): weekly black/isort/flake8 sweep

### DIFF
--- a/analyzer/test_analytics.py
+++ b/analyzer/test_analytics.py
@@ -1,6 +1,6 @@
 """Unit tests for analyzer.analytics (server-side GA4 Measurement Protocol)."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase, override_settings
 
@@ -31,7 +31,9 @@ class NoopWhenUnconfiguredTests(SimpleTestCase):
 class HappyPathTests(SimpleTestCase):
     def test_sends_expected_shape(self):
         mock_resp = MagicMock(status_code=204, text="")
-        with patch("analyzer.analytics.requests.post", return_value=mock_resp) as mock_post:
+        with patch(
+            "analyzer.analytics.requests.post", return_value=mock_resp
+        ) as mock_post:
             ok = send_ga4_event(
                 client_id="cid-1",
                 event_name="log_analysis_completed",
@@ -53,7 +55,9 @@ class HappyPathTests(SimpleTestCase):
 
     def test_omits_user_id_when_not_provided(self):
         mock_resp = MagicMock(status_code=200, text="")
-        with patch("analyzer.analytics.requests.post", return_value=mock_resp) as mock_post:
+        with patch(
+            "analyzer.analytics.requests.post", return_value=mock_resp
+        ) as mock_post:
             send_ga4_event("cid", "anon_event", {})
         body = mock_post.call_args.kwargs["json"]
         self.assertNotIn("user_id", body)


### PR DESCRIPTION
## Summary

Auto-generated by the QueryGrade weekly lint routine (2026-05-04).

- Tooling: `black` + `isort` across `analyzer/` and `querygrade/`
- Net change: **1 file changed, 7 insertions(+), 3 deletions(-)** (`analyzer/test_analytics.py`)

> Note: black reported 53 files reformatted and isort fixed 53 files, but the vast majority of those changes were idempotent relative to HEAD — only `test_analytics.py` had a net diff.

---

### Outstanding flake8 findings (manual fix required)

3,173 findings across `analyzer/` — none auto-fixable by black/isort. Breakdown by code:

| Code | Count | Description |
|------|-------|-------------|
| E501 | 2732 | Line too long (> 79 chars) |
| F401 | 324  | Imported but unused |
| F841 | 48   | Local variable assigned but never used |
| F541 | 19   | f-string without placeholders |
| F405 | 14   | May be undefined from star import |
| E203 | 14   | Whitespace before `:` |
| E402 | 8    | Module level import not at top of file |
| F811 | 7    | Redefinition of unused name |
| F403 | 5    | `import *` used |
| F821 | 2    | Undefined name |

Top findings (first 50 lines of `flake8` output):
```
analyzer/admin/__init__.py:4:80: E501 line too long (85 > 79 characters)
analyzer/admin/__init__.py:16:1: F401 '.ml_admin' imported but unused
analyzer/admin/__init__.py:16:1: F401 '.query_admin' imported but unused
analyzer/admin/__init__.py:16:1: F401 '.user_admin' imported but unused
analyzer/analyzers/base.py:19:1: F401 'django.core.cache.caches' imported but unused
analyzer/analyzers/base.py:152:9: F841 local variable 'start_time' is assigned to but never used
```
Full output available in `/tmp/flake8.txt` on the runner. Consider adding a `setup.cfg` or `pyproject.toml` `[flake8]` section with `max-line-length = 88` (black's default) to silence the E501 noise.

---

*Do NOT merge without human review.*

---
_Generated by [Claude Code](https://claude.ai/code/session_011CqV9Fmd4shvoFh3YzgCpT)_