### PR TITLE
fix(ui): make CodeMirror SQL editors follow light/dark theme

### DIFF
--- a/analyzer/static/analyzer/css/dark-mode.css
+++ b/analyzer/static/analyzer/css/dark-mode.css
@@ -159,8 +159,9 @@ html.dark ::-webkit-scrollbar-track { background: #0d1117; }
 html.dark ::-webkit-scrollbar-thumb { background: #30363d; border-radius: 4px; }
 html.dark ::-webkit-scrollbar-thumb:hover { background: #444c56; }
 
-/* ─── CodeMirror — already uses material-darker, stays consistent ─── */
-/* No overrides needed. */
+/* ─── CodeMirror — theme is toggled via window.QG.cmTheme() in base.html ─── */
+/* Light mode uses CodeMirror's built-in 'default' theme; dark mode uses 'material-darker'.
+   Editors register via window.QG.registerEditor() and re-theme on toggle. No CSS overrides needed. */
 
 /* ─── Theme toggle button ─── */
 .theme-toggle {

--- a/analyzer/templates/analyzer/base.html
+++ b/analyzer/templates/analyzer/base.html
@@ -173,11 +173,29 @@
       }
     };
 
+    // CodeMirror theme registry — keeps editors in sync with the global light/dark toggle.
+    // Templates that instantiate CodeMirror should:
+    //   theme: window.QG.cmTheme()    // initial theme
+    //   window.QG.registerEditor(ed)  // so it follows future toggles
+    window.QG = window.QG || {};
+    window.QG._cmEditors = [];
+    window.QG.cmTheme = function() {
+      return document.documentElement.classList.contains('dark') ? 'material-darker' : 'default';
+    };
+    window.QG.registerEditor = function(ed) {
+      if (ed) window.QG._cmEditors.push(ed);
+    };
+    window.QG.refreshEditorThemes = function() {
+      const t = window.QG.cmTheme();
+      window.QG._cmEditors.forEach(ed => { try { ed.setOption('theme', t); } catch (e) {} });
+    };
+
     // Theme toggle
     document.querySelector('.theme-toggle').addEventListener('click', function() {
       const html = document.documentElement;
       const isDark = html.classList.toggle('dark');
       localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      window.QG.refreshEditorThemes();
     });
 
     // Delegated nav click tracking. Reads `data-nav` from anchors inside the primary <nav>.

--- a/analyzer/templates/analyzer/base.html
+++ b/analyzer/templates/analyzer/base.html
@@ -187,7 +187,14 @@
     };
     window.QG.refreshEditorThemes = function() {
       const t = window.QG.cmTheme();
-      window.QG._cmEditors.forEach(ed => { try { ed.setOption('theme', t); } catch (e) {} });
+      window.QG._cmEditors.forEach(ed => {
+        try {
+          ed.setOption('theme', t);
+          // Defer refresh so the browser repaints before CodeMirror remeasures —
+          // covers editors that may be in a hidden tab when the toggle fires.
+          setTimeout(() => { try { ed.refresh(); } catch (e) {} }, 0);
+        } catch (e) {}
+      });
     };
 
     // Theme toggle

--- a/analyzer/templates/analyzer/batch_results.html
+++ b/analyzer/templates/analyzer/batch_results.html
@@ -118,12 +118,13 @@
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('textarea.sql-display').forEach(ta => {
     const editor = CodeMirror.fromTextArea(ta, {
-      mode: 'text/x-sql', theme: 'material-darker',
+      mode: 'text/x-sql', theme: (window.QG && window.QG.cmTheme ? window.QG.cmTheme() : 'material-darker'),
       lineNumbers: true, readOnly: true, lineWrapping: true,
       cursorBlinkRate: -1,
     });
     const lines = ta.value.split('\n').length;
     editor.setSize(null, Math.max(100, Math.min(240, lines * 20 + 30)));
+    if (window.QG && window.QG.registerEditor) window.QG.registerEditor(editor);
   });
 
   if (typeof gtag === 'function') {

--- a/analyzer/templates/analyzer/compare_results.html
+++ b/analyzer/templates/analyzer/compare_results.html
@@ -141,12 +141,13 @@
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('textarea.sql-display').forEach(ta => {
     const editor = CodeMirror.fromTextArea(ta, {
-      mode: 'text/x-sql', theme: 'material-darker',
+      mode: 'text/x-sql', theme: (window.QG && window.QG.cmTheme ? window.QG.cmTheme() : 'material-darker'),
       lineNumbers: true, readOnly: true, lineWrapping: true,
       cursorBlinkRate: -1,
     });
     const lines = ta.value.split('\n').length;
     editor.setSize(null, Math.max(120, Math.min(300, lines * 20 + 40)));
+    if (window.QG && window.QG.registerEditor) window.QG.registerEditor(editor);
   });
 });
 

--- a/analyzer/templates/analyzer/enhanced_grade_results.html
+++ b/analyzer/templates/analyzer/enhanced_grade_results.html
@@ -645,12 +645,13 @@
     document.querySelectorAll('textarea.sql-display').forEach(ta => {
       const lines = ta.value.split('\n').length;
       const ed = CodeMirror.fromTextArea(ta, {
-        mode: 'text/x-sql', theme: 'material-darker',
+        mode: 'text/x-sql', theme: (window.QG && window.QG.cmTheme ? window.QG.cmTheme() : 'material-darker'),
         lineNumbers: true, readOnly: true, lineWrapping: true,
         cursorBlinkRate: -1,
       });
       ed.setSize(null, Math.max(80, Math.min(500, lines * 20 + 40)));
       sqlEditors.push(ed);
+      if (window.QG && window.QG.registerEditor) window.QG.registerEditor(ed);
     });
 
     const issues = {{ analysis.issues_found|safe }};

--- a/analyzer/templates/analyzer/grade_form.html
+++ b/analyzer/templates/analyzer/grade_form.html
@@ -354,7 +354,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const ta = document.getElementById('{{ form.sql_query.id_for_label }}');
   if (ta) {
     sqlEditor = CodeMirror.fromTextArea(ta, {
-      mode: 'text/x-sql', theme: 'material-darker', lineNumbers: true,
+      mode: 'text/x-sql', theme: (window.QG && window.QG.cmTheme ? window.QG.cmTheme() : 'material-darker'), lineNumbers: true,
       indentUnit: 2, smartIndent: true, lineWrapping: true,
       autoCloseBrackets: true, matchBrackets: true,
       foldGutter: true, gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
@@ -376,6 +376,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (e.text[0].match(/\w/) || e.text[0] === '.') cm.showHint();
     });
     sqlEditor.on('change', () => sqlEditor.save());
+    if (window.QG && window.QG.registerEditor) window.QG.registerEditor(sqlEditor);
   }
 
   if (localStorage.getItem('querygrade_help_dismissed') === 'true') {

--- a/analyzer/templates/analyzer/grade_results.html
+++ b/analyzer/templates/analyzer/grade_results.html
@@ -493,12 +493,13 @@
     document.querySelectorAll('textarea.sql-display').forEach(ta => {
       const lines = ta.value.split('\n').length;
       const ed = CodeMirror.fromTextArea(ta, {
-        mode: 'text/x-sql', theme: 'material-darker',
+        mode: 'text/x-sql', theme: (window.QG && window.QG.cmTheme ? window.QG.cmTheme() : 'material-darker'),
         lineNumbers: true, readOnly: true, lineWrapping: true,
         cursorBlinkRate: -1,
       });
       ed.setSize(null, Math.max(80, Math.min(500, lines * 20 + 40)));
       sqlEditors.push(ed);
+      if (window.QG && window.QG.registerEditor) window.QG.registerEditor(ed);
     });
 
     const issues = JSON.parse(document.getElementById('issues-json').textContent);

--- a/analyzer/templates/analyzer/query_compare.html
+++ b/analyzer/templates/analyzer/query_compare.html
@@ -110,12 +110,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const ta = document.getElementById(id);
     if (!ta || ta.tagName !== 'TEXTAREA') return;
     const editor = CodeMirror.fromTextArea(ta, {
-      mode: 'text/x-sql', theme: 'material-darker',
+      mode: 'text/x-sql', theme: (window.QG && window.QG.cmTheme ? window.QG.cmTheme() : 'material-darker'),
       lineNumbers: true, indentUnit: 2, smartIndent: true,
       lineWrapping: true, autoCloseBrackets: true, matchBrackets: true,
     });
     editor.on('change', () => editor.save());
     sqlEditors.push(editor);
+    if (window.QG && window.QG.registerEditor) window.QG.registerEditor(editor);
   });
 });
 


### PR DESCRIPTION
## Summary
- All SQL entry and read-only display editors were hardcoded to `material-darker`, looking out of place in light mode.
- Adds a tiny theme registry in `base.html` (`window.QG.cmTheme` / `registerEditor` / `refreshEditorThemes`) wired into the existing theme-toggle click handler.
- Updates every `CodeMirror.fromTextArea` call site to pick the theme dynamically and re-theme live on toggle:
  - Entry: `grade_form.html`, `query_compare.html`
  - Display: `grade_results.html`, `enhanced_grade_results.html`, `compare_results.html`, `batch_results.html`

Light mode uses CodeMirror's built-in `default` theme (no extra CSS). Dark mode keeps `material-darker`.

## Test plan
- [ ] Visit `/grade/` in light mode — editor renders white with standard SQL syntax highlighting.
- [ ] Toggle dark — editor switches to `material-darker` instantly without reload.
- [ ] Toggle back to light — editor switches back instantly.
- [ ] Submit a query and verify `grade_results` read-only SQL display matches current theme.
- [ ] Repeat on `/compare/` (entry) and `compare_results` / `batch_results` displays.
- [ ] Hard reload in each mode and confirm initial theme matches.