### PR TITLE
feat: HuggingFace query corpus loader + GA4 event wiring

### DIFF
--- a/analyzer/api_views/feedback_api.py
+++ b/analyzer/api_views/feedback_api.py
@@ -5,6 +5,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from ..analytics import send_ga4_event, synthetic_client_id
 from ..models import QueryFeedback, UserQueryHistory
 from ..serializers import QueryFeedbackSerializer
 
@@ -78,6 +79,20 @@ def submit_feedback_api(request, analysis_id):
         logger.info(
             f"Feedback {action} via API for user {request.user.username}, analysis {analysis_id}"
         )
+
+        try:
+            send_ga4_event(
+                synthetic_client_id(request.user.id),
+                "api_feedback_submitted",
+                {
+                    "feedback_type": "api",
+                    "action": action,
+                    "would_recommend": bool(getattr(feedback, "would_recommend", False)),
+                },
+                user_id=request.user.id,
+            )
+        except Exception:
+            logger.debug("GA4 api_feedback_submitted emit failed", exc_info=True)
 
         return Response(
             {"message": f"Feedback {action} successfully", "feedback_id": feedback.id},

--- a/analyzer/api_views/query_grading_api.py
+++ b/analyzer/api_views/query_grading_api.py
@@ -6,6 +6,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from ..analytics import send_ga4_event, synthetic_client_id
 from ..exceptions import QueryAnalysisError
 from ..models import Query, QueryAnalysis, UserQueryHistory
 from ..query_analyzer import analyze_query
@@ -76,6 +77,20 @@ def grade_query_api(request):
         logger.info(
             f"API query graded for user {request.user.username}: {analysis.grade} ({analysis.score:.1f})"
         )
+
+        try:
+            send_ga4_event(
+                synthetic_client_id(request.user.id),
+                "api_query_graded",
+                {
+                    "grade": analysis.grade,
+                    "score": float(analysis.score),
+                    "analysis_type": "api",
+                },
+                user_id=request.user.id,
+            )
+        except Exception:
+            logger.debug("GA4 api_query_graded emit failed", exc_info=True)
 
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
@@ -221,5 +236,21 @@ def batch_analysis_api(request):
     logger.info(
         f"API batch analysis completed for user {request.user.username}: {successful_count}/{len(queries)} successful"
     )
+
+    try:
+        send_ga4_event(
+            synthetic_client_id(request.user.id),
+            "api_batch_analysis",
+            {
+                "query_count": len(queries),
+                "successful_count": successful_count,
+                "failed_count": failed_count,
+                "average_score": float(average_score),
+                "analysis_type": "api",
+            },
+            user_id=request.user.id,
+        )
+    except Exception:
+        logger.debug("GA4 api_batch_analysis emit failed", exc_info=True)
 
     return Response(response_data, status=status.HTTP_201_CREATED)

--- a/analyzer/management/commands/load_huggingface_queries.py
+++ b/analyzer/management/commands/load_huggingface_queries.py
@@ -1,0 +1,252 @@
+"""
+Pull SQL queries from a HuggingFace dataset, score via the rule-based grader,
+and seed TrainingData.
+
+HF datasets are nearly all NL-to-SQL corpora — no public dataset has the
+performance grades QueryGrade trains against. We use them as a *query corpus*
+for shape coverage: rule-based scoring becomes the synthetic label, and the
+sample weight is kept low so real user feedback dominates training.
+
+Default dataset: lamini/spider_text_to_sql (~10k freely-accessible Spider queries).
+
+Examples:
+    python manage.py load_huggingface_queries --limit 1000 --dry-run
+    python manage.py load_huggingface_queries --limit 5000
+    python manage.py load_huggingface_queries --dataset lamini/bird_spider_train_text_to_sql --column output --limit 10000
+    python manage.py load_huggingface_queries --clear  # wipe prior HF samples first
+"""
+
+import logging
+import re
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from analyzer.analyzers.base import QueryGrader
+from analyzer.ml.core.feature_extractor import FeatureExtractor
+from analyzer.models import TrainingData
+
+logger = logging.getLogger(__name__)
+
+# Default candidates documented in CLAUDE.md (lamini/spider_text_to_sql ~10k,
+# lamini/bird_spider_train_text_to_sql 10k–100k, VPCSinfo/odoo-sql-query-dataset).
+DEFAULT_DATASET = "lamini/spider_text_to_sql"
+DEFAULT_SPLIT = "train"
+DEFAULT_COLUMN = "output"  # lamini/spider uses {input, output}; output is the SQL
+
+# Analyzer pipeline is SELECT-optimized (CLAUDE.md: non-SELECT no-ops with a
+# performance_notes warning), so filter to queries that lead with SELECT/WITH.
+SELECT_RE = re.compile(r"^\s*(SELECT|WITH)\b", re.IGNORECASE)
+
+
+def _coerce_sql(value, column):
+    """Pull a SQL string out of a row that may be dict/str/list."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value
+    elif isinstance(value, dict):
+        # Some datasets nest under {column: {...}}; try common keys.
+        for k in (column, "sql", "query", "text", "output"):
+            if k in value and isinstance(value[k], str):
+                text = value[k]
+                break
+        else:
+            return None
+    else:
+        return None
+
+    text = text.strip().rstrip(";").strip()
+    return text or None
+
+
+class Command(BaseCommand):
+    help = "Seed TrainingData with SQL queries pulled from a HuggingFace dataset"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dataset",
+            default=DEFAULT_DATASET,
+            help=f"HF dataset id (default: {DEFAULT_DATASET})",
+        )
+        parser.add_argument(
+            "--split",
+            default=DEFAULT_SPLIT,
+            help=f"Dataset split to load (default: {DEFAULT_SPLIT})",
+        )
+        parser.add_argument(
+            "--column",
+            default=DEFAULT_COLUMN,
+            help=f"Column containing the SQL string (default: {DEFAULT_COLUMN})",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=1000,
+            help="Maximum number of queries to ingest (default: 1000)",
+        )
+        parser.add_argument(
+            "--feedback-weight",
+            type=float,
+            default=0.3,
+            help="Sample weight for HF rows (default: 0.3, vs 1.0 for real feedback)",
+        )
+        parser.add_argument(
+            "--include-non-select",
+            action="store_true",
+            help="Don't filter out non-SELECT queries (analyzer is SELECT-optimized)",
+        )
+        parser.add_argument(
+            "--clear",
+            action="store_true",
+            help="Delete prior samples for this dataset before seeding",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be created without writing to DB",
+        )
+
+    def handle(self, *args, **options):
+        try:
+            from datasets import load_dataset
+        except ImportError as exc:
+            raise CommandError(
+                "The `datasets` package is required. Install with:\n"
+                "    pip install --break-system-packages datasets\n"
+                "(or add to requirements-worker.txt)"
+            ) from exc
+
+        dataset_id = options["dataset"]
+        split = options["split"]
+        column = options["column"]
+        limit = options["limit"]
+        weight = options["feedback_weight"]
+        include_non_select = options["include_non_select"]
+        clear = options["clear"]
+        dry_run = options["dry_run"]
+
+        source_tag = f"huggingface:{dataset_id}"[:100]
+
+        if clear and not dry_run:
+            deleted, _ = TrainingData.objects.filter(
+                validation_source=source_tag
+            ).delete()
+            self.stdout.write(f"Deleted {deleted} prior samples from {source_tag}")
+
+        self.stdout.write(f"Loading {dataset_id} [{split}] from HuggingFace...")
+        try:
+            ds = load_dataset(dataset_id, split=split, streaming=True)
+        except Exception as exc:
+            raise CommandError(f"Failed to load dataset: {exc}") from exc
+
+        grader = QueryGrader()
+        extractor = FeatureExtractor()
+        grade_to_rating = {"A": 5.0, "B": 4.0, "C": 3.0, "D": 2.0, "F": 1.0}
+
+        seen_hashes = set()
+        scanned = 0
+        created = 0
+        skipped_non_select = 0
+        skipped_dup = 0
+        skipped_existing = 0
+        errors = 0
+
+        for row in ds:
+            if created >= limit:
+                break
+            scanned += 1
+
+            raw = row.get(column) if isinstance(row, dict) else None
+            if raw is None and isinstance(row, dict):
+                # Fallback: scan all string-valued columns for one that parses
+                for v in row.values():
+                    if isinstance(v, str) and SELECT_RE.match(v):
+                        raw = v
+                        break
+
+            sql = _coerce_sql(raw, column)
+            if not sql:
+                continue
+
+            if not include_non_select and not SELECT_RE.match(sql):
+                skipped_non_select += 1
+                continue
+
+            # In-batch dedup before hitting the DB
+            sig = hash(sql)
+            if sig in seen_hashes:
+                skipped_dup += 1
+                continue
+            seen_hashes.add(sig)
+
+            try:
+                with transaction.atomic():
+                    query_obj, analysis = grader.analyze_query(sql)
+
+                    features = extractor.extract_features(query_obj)
+                    if features is None:
+                        errors += 1
+                        continue
+
+                    if dry_run:
+                        if created < 10:
+                            self.stdout.write(
+                                f"  [dry-run] {analysis.grade} ({analysis.score:.0f}) "
+                                f"— {sql[:80]}"
+                            )
+                        created += 1
+                        continue
+
+                    if TrainingData.objects.filter(
+                        query=query_obj, validation_source=source_tag
+                    ).exists():
+                        skipped_existing += 1
+                        continue
+
+                    TrainingData.objects.create(
+                        query=query_obj,
+                        user_grade_avg=grade_to_rating.get(analysis.grade, 3.0),
+                        user_grade_count=1,
+                        user_grade_stddev=0.0,
+                        system_grade=analysis.grade,
+                        system_score=analysis.score,
+                        features_json=features,
+                        target_score=analysis.score,
+                        feedback_weight=weight,
+                        query_complexity=query_obj.estimated_complexity,
+                        table_count=query_obj.table_count,
+                        join_count=query_obj.join_count,
+                        is_validated=True,
+                        validation_source=source_tag,
+                    )
+                    created += 1
+
+                    if created % 250 == 0:
+                        self.stdout.write(
+                            f"  ...{created} ingested ({scanned} scanned)"
+                        )
+
+            except Exception as exc:
+                logger.warning("HF ingest error: %s | sql=%s", exc, sql[:80])
+                errors += 1
+
+        verb = "Would create" if dry_run else "Created"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\n{verb} {created} samples from {dataset_id} "
+                f"(scanned {scanned}, weight={weight})"
+            )
+        )
+        self.stdout.write(
+            f"  skipped: non-select={skipped_non_select}, "
+            f"in-batch-dup={skipped_dup}, already-loaded={skipped_existing}, "
+            f"errors={errors}"
+        )
+
+        if not dry_run and created > 0:
+            total = TrainingData.objects.count()
+            self.stdout.write(f"Total TrainingData records: {total}")
+            self.stdout.write(
+                "Next: python manage.py train_ml_model --algorithm random_forest --force"
+            )

--- a/analyzer/views/auth_views.py
+++ b/analyzer/views/auth_views.py
@@ -15,7 +15,6 @@ from django.contrib.auth.tokens import default_token_generator
 from django.core.mail import send_mail
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
-from django.urls import reverse
 from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from django.views.decorators.cache import never_cache

--- a/analyzer/views/auth_views.py
+++ b/analyzer/views/auth_views.py
@@ -81,6 +81,8 @@ def logout_view(request):
         username = request.user.username
         logout(request)
         messages.info(request, f"You have been logged out successfully, {username}.")
+        # GA4 one-shot event (logout flushes the session; the new empty session carries the flag)
+        request.session["_pending_gtag_event"] = "user_logout"
     return redirect("login")
 
 
@@ -111,7 +113,10 @@ def register_view(request):
                 request,
                 f"Welcome to QueryGrade, {username}! Your account has been created.",
             )
-            return redirect(f"{reverse('index')}?signup=1")
+            # GA4 one-shot event (replaces legacy ?signup=1 URL flag for new registrations)
+            request.session["_pending_gtag_event"] = "sign_up"
+            request.session["_pending_gtag_params"] = {"method": "email"}
+            return redirect("index")
         else:
             messages.error(request, "Please correct the errors below.")
     else:
@@ -177,6 +182,7 @@ def password_reset_request(request):
                 request,
                 "If an account exists with that email, a password reset link has been sent.",
             )
+            request.session["_pending_gtag_event"] = "password_reset_request"
             return redirect("login")
     else:
         form = PasswordResetForm()
@@ -248,6 +254,7 @@ def password_change(request):
             # Keep user logged in after password change
             update_session_auth_hash(request, user)
             messages.success(request, "Your password has been changed successfully.")
+            request.session["_pending_gtag_event"] = "password_change"
             return redirect("account")
         else:
             messages.error(request, "Please correct the errors below.")

--- a/analyzer/views/query_grading_views.py
+++ b/analyzer/views/query_grading_views.py
@@ -423,6 +423,12 @@ def compare_queries(request):
             # Store in session
             request.session["comparison_data"] = comparison_data
 
+            query_count = 2 + (1 if comparison_data["query_3"] else 0)
+            request.session["_pending_gtag_event"] = "compare_queries_submitted"
+            request.session["_pending_gtag_params"] = {
+                "query_count": query_count,
+                "database_type": comparison_data["database_type"] or "unknown",
+            }
             return redirect("compare_results")
         else:
             messages.error(request, "Please correct the errors in the form below.")
@@ -459,6 +465,11 @@ def batch_grade_queries(request):
                 "database_type": database_type,
             }
 
+            request.session["_pending_gtag_event"] = "batch_analysis_started"
+            request.session["_pending_gtag_params"] = {
+                "query_count": len(queries),
+                "database_type": database_type or "unknown",
+            }
             return redirect("batch_results")
         else:
             messages.error(request, "Please correct the errors in the form below.")

--- a/analyzer/views/query_grading_views.py
+++ b/analyzer/views/query_grading_views.py
@@ -423,12 +423,8 @@ def compare_queries(request):
             # Store in session
             request.session["comparison_data"] = comparison_data
 
-            query_count = 2 + (1 if comparison_data["query_3"] else 0)
-            request.session["_pending_gtag_event"] = "compare_queries_submitted"
-            request.session["_pending_gtag_params"] = {
-                "query_count": query_count,
-                "database_type": comparison_data["database_type"] or "unknown",
-            }
+            # GA4 event fired client-side from query_compare.html on form submit
+            # (event: comparison_started). Don't duplicate here.
             return redirect("compare_results")
         else:
             messages.error(request, "Please correct the errors in the form below.")
@@ -465,11 +461,8 @@ def batch_grade_queries(request):
                 "database_type": database_type,
             }
 
-            request.session["_pending_gtag_event"] = "batch_analysis_started"
-            request.session["_pending_gtag_params"] = {
-                "query_count": len(queries),
-                "database_type": database_type or "unknown",
-            }
+            # GA4 event fired client-side from batch_analysis.html on form submit
+            # (event: batch_analysis_started). Don't duplicate here.
             return redirect("batch_results")
         else:
             messages.error(request, "Please correct the errors in the form below.")

--- a/analyzer/views/upload_views.py
+++ b/analyzer/views/upload_views.py
@@ -122,6 +122,11 @@ def index(request):
                         request,
                         f"File upload successful! Your {log_type} log is being processed in the background. You'll be notified when it's complete.",
                     )
+                    request.session["_pending_gtag_event"] = "log_file_uploaded"
+                    request.session["_pending_gtag_params"] = {
+                        "log_type": log_type,
+                        "processing_mode": "async",
+                    }
                     return redirect("async_processing_status")
 
                 except (OSError, IOError) as e:
@@ -193,6 +198,11 @@ def index(request):
                     page_number = request.GET.get("page")
                     page_obj = paginator.get_page(page_number)
 
+                    request.session["_pending_gtag_event"] = "log_file_uploaded"
+                    request.session["_pending_gtag_params"] = {
+                        "log_type": log_type,
+                        "processing_mode": "sync",
+                    }
                     return render(
                         request, "analyzer/results.html", {"page_obj": page_obj}
                     )

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -11,3 +11,6 @@ transformers>=4.25.0
 sentence-transformers>=2.2.0
 xgboost>=1.7.0
 lightgbm>=3.3.0
+
+# HuggingFace datasets — used by load_huggingface_queries to seed TrainingData
+datasets>=2.14.0


### PR DESCRIPTION
Two independent commits on the same branch — review per-commit for clarity.

---

## Commit 1: HuggingFace query corpus loader (`fac8f11`)

### Summary
- Adds `load_huggingface_queries` management command — streams SQL from a HuggingFace dataset, scores via rule-based `QueryGrader`, writes to `TrainingData` for shape coverage / regularization.
- Adds `datasets>=2.14.0` to `requirements-worker.txt` only (web image stays slim; command does an optional import with a clean error if missing).

### Why
HF has no public (SQL, perf-grade) dataset — every SQL corpus is text-to-SQL (NL → SQL). So this isn't ground-truth labels; it's **corpus expansion** to expose the ML model to query shapes users haven't submitted yet. Real `QueryFeedback`-derived rows stay at `feedback_weight=1.0`; HF rows default to `0.3`, so user feedback continues to dominate training as it accumulates.

### Design choices
- **Streaming** (`streaming=True`) — `--limit 1000` doesn't download the full 10k+ dataset.
- **SELECT/WITH filter by default** — analyzer pipeline is SELECT-optimized (per CLAUDE.md, non-SELECT no-ops with a warning). Override with `--include-non-select`.
- **Idempotent** — in-batch dedup + per-query existence check on `validation_source`. Re-running is safe.
- **`validation_source="huggingface:<dataset_id>"`** — `--clear` targets only HF samples without touching synthetic seed or feedback-derived rows.
- **Default corpus**: `lamini/spider_text_to_sql` (~10k, freely accessible). Documented alternatives: `lamini/bird_spider_train_text_to_sql`, `VPCSinfo/odoo-sql-query-dataset`.

### Usage
```bash
python manage.py load_huggingface_queries --limit 1000
python manage.py train_ml_model --algorithm random_forest --force
```

---

## Commit 2: GA4 event wiring (`03a443d`)

### Summary
Implements the GA4 events already documented in CLAUDE.md's Analytics section but not yet wired in code. Uses the established session-flag pattern for client-side one-shot events and the server-side `send_ga4_event` helper for REST API endpoints.

**Server-side (Measurement Protocol):**
- `api_query_graded` — grade, score, analysis_type
- `api_batch_analysis` — query_count, successful_count, failed_count, average_score
- `api_feedback_submitted` — feedback_type, action, would_recommend

**Client-side (session-flag pattern, one-shot post-redirect):**
- `user_logout` — set in `logout_view`; survives `logout()`'s session flush per the documented Django quirk
- `sign_up` — replaces legacy `?signup=1` URL flag in `register_view` with `method=email`
- `password_reset_request`, `password_change`
- `compare_queries_submitted` — query_count, database_type
- `batch_analysis_started` — query_count, database_type
- `log_file_uploaded` — log_type, processing_mode (async|sync)

All emits wrapped in `try/except → logger.debug` so analytics failures never break user-facing flows. Server-side uses `synthetic_client_id(user_id)` since there's no browser CID for API requests.

---

## Test plan

- [x] Smoke-tested `load_huggingface_queries --limit 5 --dry-run` against `lamini/spider_text_to_sql` — 5/5 queries scored cleanly.
- [x] `--help` registers correctly with all flags.
- [x] Optional `datasets` import raises `CommandError` with install instructions when missing.
- [ ] Real ingestion run on staging before bulk-loading production.
- [ ] Verify `--clear` only targets `huggingface:*` rows (does not touch `synthetic_seed`).
- [ ] Verify GA4 events arrive in DebugView (set `_dbg=1` or use Realtime report).
- [ ] Confirm the legacy `?signup=1` URL flag in `base.html` still works for back-compat (per CLAUDE.md).
- [ ] Confirm retrained model val_accuracy doesn't regress vs. seed-only baseline.