### PR TITLE
feat(ui): minimalist anon landing with inline AJAX grading

### DIFF
--- a/analyzer/templates/analyzer/base.html
+++ b/analyzer/templates/analyzer/base.html
@@ -118,13 +118,15 @@
               <svg class="icon-sun w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M12 8a4 4 0 100 8 4 4 0 000-8z"/></svg>
             </button>
             {% if anon_trial_cap %}
-            <span class="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold mr-1
+            <span id="anon-credits-pill"
+                  data-anon-cap="{{ anon_trial_cap }}"
+                  class="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold mr-1
                          {% if anon_trial_remaining == 0 %}bg-red-100 text-red-700
                          {% elif anon_trial_remaining <= 5 %}bg-amber-100 text-amber-700
                          {% else %}bg-emerald-100 text-emerald-700{% endif %}"
                   title="Free queries remaining this session. Sign up for unlimited.">
               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
-              {{ anon_trial_remaining }}/{{ anon_trial_cap }} credits
+              <span data-anon-credits>{{ anon_trial_remaining }}</span>/{{ anon_trial_cap }} credits
             </span>
             {% endif %}
             <a href="{% url 'login' %}" data-nav="login" class="px-3 py-1.5 rounded text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100">Login</a>

--- a/analyzer/templates/analyzer/grade_results.html
+++ b/analyzer/templates/analyzer/grade_results.html
@@ -597,7 +597,17 @@
       });
     }, 100);
 
-    if (typeof gtag === 'function') {
+    // Skip if the inline landing-page flow already emitted query_graded for
+    // this analysis (anon "View full report" path). One-shot — clear after.
+    var _inlineKey = 'qg_inline_counted_{{ analysis.id }}';
+    var _alreadyCounted = false;
+    try {
+      if (sessionStorage.getItem(_inlineKey)) {
+        _alreadyCounted = true;
+        sessionStorage.removeItem(_inlineKey);
+      }
+    } catch (e) {}
+    if (!_alreadyCounted && typeof gtag === 'function') {
       gtag('event', 'query_graded', {
         grade: '{{ analysis.grade|escapejs }}',
         score: {{ analysis.score|default:0 }},

--- a/analyzer/templates/analyzer/index.html
+++ b/analyzer/templates/analyzer/index.html
@@ -157,13 +157,10 @@ if (document.getElementById('uploadForm')) {
           <div>
             <label for="id_database_type" class="block text-xs font-medium text-gray-700 dark:text-gray-300">Database</label>
             <select id="id_database_type" name="database_type" class="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-[#30363d] rounded-md text-sm bg-white dark:bg-[#0d1117] dark:text-[#e6edf3]">
-              <option value="">Any / not sure</option>
-              <option value="mysql">MySQL</option>
-              <option value="postgresql">PostgreSQL</option>
-              <option value="sqlite">SQLite</option>
-              <option value="oracle">Oracle</option>
-              <option value="sqlserver">SQL Server</option>
-              <option value="other">Other</option>
+              {# Choices sourced from QueryGradeForm.DATABASE_CHOICES so this stays in sync if the form changes. #}
+              {% for value, label in grade_form.database_type.field.choices %}
+              <option value="{{ value }}">{{ label }}</option>
+              {% endfor %}
             </select>
           </div>
           <div>
@@ -392,6 +389,9 @@ if (document.getElementById('uploadForm')) {
       });
     }
 
+    // GA4 dedup: mark this analysis as already-counted so /grade/results/<id>/
+    // skips its own query_graded emit (it fires on page load unconditionally).
+    try { sessionStorage.setItem('qg_inline_counted_' + d.analysis_id, '1'); } catch (e) {}
     window.trackEvent('query_graded', {
       grade: grade,
       score: typeof d.score === 'number' ? d.score : parseFloat(d.score) || 0,
@@ -399,6 +399,7 @@ if (document.getElementById('uploadForm')) {
     });
   }
 
+  let formLocked = false;
   function renderExhausted(d) {
     resultPanel.innerHTML = `
       <section class="bg-white dark:bg-[#161b22] rounded-xl border border-indigo-200 dark:border-indigo-900 p-8 text-center space-y-4 shadow-sm">
@@ -412,8 +413,18 @@ if (document.getElementById('uploadForm')) {
       </section>
     `;
     resultPanel.classList.remove('hidden');
+    formLocked = true;
     submitBtn.disabled = true;
-    window.trackEvent('trial_exhausted', { trial_cap: d.cap, queries_used: d.cap });
+    // One-shot per session — also gates against duplicate emits if the user later
+    // hits the legacy /grade/ POST exhausted branch (which fires server-side).
+    try {
+      if (!sessionStorage.getItem('qg_trial_exhausted_fired')) {
+        sessionStorage.setItem('qg_trial_exhausted_fired', '1');
+        window.trackEvent('trial_exhausted', { trial_cap: d.cap, queries_used: d.cap });
+      }
+    } catch (e) {
+      window.trackEvent('trial_exhausted', { trial_cap: d.cap, queries_used: d.cap });
+    }
   }
 
   function renderErrors(errors) {
@@ -486,7 +497,8 @@ if (document.getElementById('uploadForm')) {
       finishStaged();
       showToast('Network error. Please try again.', 'error');
     } finally {
-      submitBtn.disabled = false;
+      // Don't re-enable if renderExhausted locked the form — the trial is over.
+      if (!formLocked) submitBtn.disabled = false;
     }
   }
 

--- a/analyzer/templates/analyzer/index.html
+++ b/analyzer/templates/analyzer/index.html
@@ -1,16 +1,15 @@
 {% extends 'analyzer/base.html' %}
 {% load static %}
 
-{% block title %}Dashboard · QueryGrade{% endblock %}
+{% block title %}{% if user.is_authenticated %}Dashboard · QueryGrade{% else %}QueryGrade · Grade any SQL query{% endif %}{% endblock %}
 
 {% block content %}
+{% if user.is_authenticated %}
 <div class="space-y-8">
   <header>
     <h1 class="text-3xl font-bold text-gray-900">QueryGrade</h1>
     <p class="mt-1 text-gray-600">SQL query analysis and database optimization platform</p>
-    {% if user.is_authenticated %}
     <p class="mt-2 text-sm text-gray-500">Welcome back, <span class="font-medium text-gray-700">{{ user.username }}</span>.</p>
-    {% endif %}
   </header>
 
   <section class="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -40,7 +39,6 @@
     </a>
   </section>
 
-  {% if user.is_authenticated %}
   <section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
     <a href="{% url 'grade_query' %}" class="bg-white rounded-lg border border-gray-200 p-4 hover:border-indigo-300 hover:shadow-sm transition flex items-center gap-3">
       <span class="text-2xl">⚡</span>
@@ -92,70 +90,6 @@
     </form>
   </section>
   {% endif %}
-  {% else %}
-  {# Anonymous trial: inline grade form + upgrade CTA #}
-  {% if trial_exhausted %}
-  <section class="bg-white rounded-lg border border-indigo-200 p-8 text-center space-y-4">
-    <div class="text-4xl">🚀</div>
-    <h2 class="text-2xl font-semibold text-gray-900">You've used all {{ trial_cap }} free trials</h2>
-    <p class="text-gray-600 max-w-xl mx-auto">Create a free account to keep grading queries — plus unlock AI rewrite suggestions, personalized feedback, query history, and saved reports.</p>
-    <div class="flex gap-3 justify-center pt-2">
-      <a href="{% url 'register' %}" class="px-6 py-2.5 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">Create free account</a>
-      <a href="{% url 'login' %}" class="px-6 py-2.5 border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50">Log in</a>
-    </div>
-  </section>
-  {% else %}
-  <section class="bg-white rounded-lg border border-gray-200 p-6 space-y-4">
-    {% if trial_remaining <= 10 %}
-    <div class="rounded-md bg-amber-50 border border-amber-200 p-3 flex items-start gap-3">
-      <span class="text-xl">🎁</span>
-      <div class="flex-1 text-sm text-amber-900">
-        <strong>Only {{ trial_remaining }} of {{ trial_cap }} free grades left</strong> this session.
-        <a href="{% url 'register' %}" class="font-semibold underline hover:text-amber-950">Sign up</a>
-        for unlimited grading + AI rewrite suggestions, history, and saved reports.
-      </div>
-    </div>
-    {% endif %}
-
-    <form method="post" action="{% url 'grade_query' %}" class="space-y-4">
-      {% csrf_token %}
-      <div>
-        <label for="{{ grade_form.sql_query.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ grade_form.sql_query.label }} <span class="text-red-600">*</span></label>
-        <div class="mt-1">{{ grade_form.sql_query }}</div>
-        {% if grade_form.sql_query.help_text %}<p class="mt-1 text-xs text-gray-500">{{ grade_form.sql_query.help_text }}</p>{% endif %}
-      </div>
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div>
-          <label for="{{ grade_form.database_type.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ grade_form.database_type.label }}</label>
-          <div class="mt-1">{{ grade_form.database_type }}</div>
-        </div>
-        <div>
-          <label for="{{ grade_form.database_version.id_for_label }}" class="block text-sm font-medium text-gray-700">{{ grade_form.database_version.label }}</label>
-          <div class="mt-1">{{ grade_form.database_version }}</div>
-        </div>
-      </div>
-      <button type="submit" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">
-        📊 Grade my query
-      </button>
-    </form>
-  </section>
-
-  <section class="bg-white rounded-lg border border-gray-200 p-6">
-    <h2 class="text-lg font-semibold text-gray-900">Unlock more with a free account</h2>
-    <p class="mt-1 text-sm text-gray-500">Registered users get advanced ML-powered insights and persistent storage.</p>
-    <ul class="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-      <li class="flex items-start gap-2"><span>🤖</span><div><strong class="text-gray-900">AI rewrite suggestions</strong><p class="text-xs text-gray-500">Automatic query optimizations.</p></div></li>
-      <li class="flex items-start gap-2"><span>🎯</span><div><strong class="text-gray-900">Personalized feedback</strong><p class="text-xs text-gray-500">Based on your query patterns.</p></div></li>
-      <li class="flex items-start gap-2"><span>🕒</span><div><strong class="text-gray-900">Query history</strong><p class="text-xs text-gray-500">Browse and reload past analyses.</p></div></li>
-      <li class="flex items-start gap-2"><span>💾</span><div><strong class="text-gray-900">Saved reports</strong><p class="text-xs text-gray-500">Persistent records of every grade.</p></div></li>
-    </ul>
-    <div class="mt-5 flex gap-3">
-      <a href="{% url 'register' %}" class="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">Create free account</a>
-      <a href="{% url 'login' %}" class="px-4 py-2 border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50">Log in</a>
-    </div>
-  </section>
-  {% endif %}
-  {% endif %}
 </div>
 
 <script>
@@ -176,4 +110,393 @@ if (document.getElementById('uploadForm')) {
   });
 }
 </script>
+
+{% else %}
+{# ─── Anonymous landing: minimalist inline grader ─── #}
+<div class="max-w-3xl mx-auto space-y-10">
+
+  <header class="text-center space-y-3 pt-2">
+    <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-gray-900 dark:text-white">Grade any SQL query in seconds.</h1>
+    <p class="text-lg text-gray-600 dark:text-gray-300">Paste a query, get a letter grade and concrete fixes. Free, no signup required.</p>
+    {% if not trial_exhausted and trial_remaining %}
+    <p class="text-xs text-gray-500">
+      <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 font-medium">
+        {{ trial_remaining }} of {{ trial_cap }} free grades remaining this session
+      </span>
+    </p>
+    {% endif %}
+  </header>
+
+  {% if trial_exhausted %}
+  <section class="bg-white dark:bg-[#161b22] rounded-xl border border-indigo-200 dark:border-indigo-900 p-8 text-center space-y-4 shadow-sm">
+    <div class="text-4xl">🚀</div>
+    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white">You've used all {{ trial_cap }} free trials</h2>
+    <p class="text-gray-600 dark:text-gray-300 max-w-xl mx-auto">Create a free account to keep grading queries — plus unlock AI rewrite suggestions, personalized feedback, query history, and saved reports.</p>
+    <div class="flex gap-3 justify-center pt-2">
+      <a href="{% url 'register' %}" class="px-6 py-2.5 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">Create free account</a>
+      <a href="{% url 'login' %}" class="px-6 py-2.5 border border-gray-300 dark:border-[#30363d] text-gray-700 dark:text-gray-200 text-sm font-medium rounded-md hover:bg-gray-50 dark:hover:bg-[#21262d]">Log in</a>
+    </div>
+  </section>
+  {% else %}
+
+  {# Input card #}
+  <section class="bg-white dark:bg-[#161b22] rounded-xl border border-gray-200 dark:border-[#30363d] shadow-sm p-6 sm:p-8">
+    <form id="inlineGradeForm" class="space-y-4" novalidate>
+      {% csrf_token %}
+      <div>
+        <label for="id_sql_query" class="sr-only">SQL query</label>
+        <textarea id="id_sql_query" name="sql_query" rows="8"
+                  class="w-full px-4 py-3 border border-gray-300 dark:border-[#30363d] rounded-lg text-sm font-mono bg-gray-50 dark:bg-[#0d1117] dark:text-[#e6edf3] focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                  placeholder="SELECT u.name, COUNT(o.id)&#10;FROM users u&#10;LEFT JOIN orders o ON o.user_id = u.id&#10;WHERE u.created_at >= '2024-01-01'&#10;GROUP BY u.name&#10;ORDER BY 2 DESC;"></textarea>
+        <p id="sqlError" class="mt-2 text-sm text-red-600 hidden"></p>
+      </div>
+
+      <details class="text-sm text-gray-600 dark:text-gray-400">
+        <summary class="cursor-pointer select-none hover:text-gray-900 dark:hover:text-white">Database details (optional)</summary>
+        <div class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label for="id_database_type" class="block text-xs font-medium text-gray-700 dark:text-gray-300">Database</label>
+            <select id="id_database_type" name="database_type" class="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-[#30363d] rounded-md text-sm bg-white dark:bg-[#0d1117] dark:text-[#e6edf3]">
+              <option value="">Any / not sure</option>
+              <option value="mysql">MySQL</option>
+              <option value="postgresql">PostgreSQL</option>
+              <option value="sqlite">SQLite</option>
+              <option value="oracle">Oracle</option>
+              <option value="sqlserver">SQL Server</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+          <div>
+            <label for="id_database_version" class="block text-xs font-medium text-gray-700 dark:text-gray-300">Version</label>
+            <input id="id_database_version" name="database_version" type="text" placeholder="e.g. 8.0, 15"
+                   class="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-[#30363d] rounded-md text-sm bg-white dark:bg-[#0d1117] dark:text-[#e6edf3]">
+          </div>
+        </div>
+      </details>
+
+      <div class="flex items-center justify-between">
+        <button type="submit" id="gradeBtn"
+                class="inline-flex items-center gap-2 px-5 py-2.5 bg-indigo-600 text-white text-sm font-semibold rounded-md hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+          Grade my query
+        </button>
+        <p class="text-xs text-gray-500">Press <kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] text-[10px] font-mono">⌘ ↵</kbd> to submit</p>
+      </div>
+    </form>
+  </section>
+
+  {# Loading panel #}
+  <section id="loadingPanel" class="hidden bg-white dark:bg-[#161b22] rounded-xl border border-gray-200 dark:border-[#30363d] shadow-sm p-6">
+    <div class="flex items-center gap-3">
+      <svg class="animate-spin w-5 h-5 text-indigo-600" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>
+      <p id="loadingLabel" class="text-sm font-medium text-gray-700 dark:text-gray-200">Parsing SQL…</p>
+    </div>
+    <div class="mt-3 h-2 bg-gray-100 dark:bg-[#0d1117] rounded overflow-hidden">
+      <div id="loadingBar" class="h-full bg-indigo-600 transition-all duration-500 ease-out" style="width: 0%"></div>
+    </div>
+    <ul class="mt-3 grid grid-cols-4 gap-2 text-[11px] text-gray-500 dark:text-gray-400">
+      <li data-stage="0">Parse</li>
+      <li data-stage="1">Analyze clauses</li>
+      <li data-stage="2">Check indexes</li>
+      <li data-stage="3">Score</li>
+    </ul>
+  </section>
+
+  {# Result panel #}
+  <section id="resultPanel" class="hidden space-y-4"></section>
+
+  {# How it works #}
+  <section class="space-y-4 pt-4">
+    <h2 class="text-2xl font-bold text-gray-900 dark:text-white text-center">How QueryGrade works</h2>
+    <p class="text-center text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">Every grade is the product of deterministic rules <em>and</em> a model that keeps learning from real engineers like you.</p>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 pt-2">
+      <div class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+        <div class="text-2xl">📐</div>
+        <h3 class="mt-2 font-semibold text-gray-900 dark:text-white">Rule-based grading</h3>
+        <p class="mt-1.5 text-sm text-gray-600 dark:text-gray-300">Nine specialized analyzers (SELECT, JOIN, WHERE, indexing, subqueries, ORDER BY, GROUP BY, plus MySQL- and PostgreSQL-specific patterns) detect <strong>18+ issue types</strong> and emit <strong>27+ recommendation types</strong>. Output is a letter grade A–F with a 0–100 score.</p>
+      </div>
+
+      <div class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+        <div class="text-2xl">🤖</div>
+        <h3 class="mt-2 font-semibold text-gray-900 dark:text-white">ML-powered refinement</h3>
+        <p class="mt-1.5 text-sm text-gray-600 dark:text-gray-300">A hybrid model trained on curated query corpora and user feedback weights the rule-based score. When the model is confident, its prediction nudges the final grade so it reflects how queries actually perform — not just how strict our rules are.</p>
+      </div>
+
+      <div class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+        <div class="text-2xl">🧠</div>
+        <h3 class="mt-2 font-semibold text-gray-900 dark:text-white">You make it smarter</h3>
+        <p class="mt-1.5 text-sm text-gray-600 dark:text-gray-300">Every thumbs-up / thumbs-down on an analysis becomes training data. Periodic retraining means today's grades reflect what real engineers found helpful yesterday.</p>
+        <a href="{% url 'register' %}" class="mt-3 inline-flex items-center gap-1 text-sm font-medium text-indigo-700 dark:text-indigo-300 hover:underline">Create a free account →</a>
+      </div>
+    </div>
+  </section>
+
+  {% endif %}
+</div>
+
+{# Inline JS — keeps things self-contained; no new static file. #}
+<script>
+(function() {
+  const form = document.getElementById('inlineGradeForm');
+  if (!form) return;
+
+  const sqlInput = document.getElementById('id_sql_query');
+  const sqlError = document.getElementById('sqlError');
+  const submitBtn = document.getElementById('gradeBtn');
+  const loadingPanel = document.getElementById('loadingPanel');
+  const loadingBar = document.getElementById('loadingBar');
+  const loadingLabel = document.getElementById('loadingLabel');
+  const resultPanel = document.getElementById('resultPanel');
+
+  const STAGES = [
+    { label: 'Parsing SQL…',         pct: 22 },
+    { label: 'Analyzing clauses…',   pct: 48 },
+    { label: 'Checking indexes…',    pct: 72 },
+    { label: 'Scoring…',             pct: 90 },
+  ];
+
+  let stageTimers = [];
+  function clearStageTimers() {
+    stageTimers.forEach(t => clearTimeout(t));
+    stageTimers = [];
+  }
+
+  function startStaged() {
+    loadingPanel.classList.remove('hidden');
+    loadingBar.style.width = '0%';
+    loadingLabel.textContent = STAGES[0].label;
+    clearStageTimers();
+    STAGES.forEach((s, i) => {
+      stageTimers.push(setTimeout(() => {
+        loadingLabel.textContent = s.label;
+        loadingBar.style.width = s.pct + '%';
+        document.querySelectorAll('#loadingPanel li').forEach((el, idx) => {
+          el.classList.toggle('text-indigo-700', idx <= i);
+          el.classList.toggle('dark:text-indigo-300', idx <= i);
+          el.classList.toggle('font-semibold', idx <= i);
+        });
+      }, 400 + i * 380));
+    });
+  }
+
+  function finishStaged() {
+    clearStageTimers();
+    loadingBar.style.width = '100%';
+    loadingLabel.textContent = 'Done.';
+    setTimeout(() => { loadingPanel.classList.add('hidden'); }, 280);
+  }
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  const GRADE_THEME = {
+    A: { surface: 'bg-emerald-50 ring-emerald-200', text: 'text-emerald-700', label: 'Excellent' },
+    B: { surface: 'bg-lime-50 ring-lime-200',       text: 'text-lime-700',    label: 'Good' },
+    C: { surface: 'bg-amber-50 ring-amber-200',     text: 'text-amber-700',   label: 'Average' },
+    D: { surface: 'bg-orange-50 ring-orange-200',   text: 'text-orange-700',  label: 'Poor' },
+    F: { surface: 'bg-red-50 ring-red-200',         text: 'text-red-700',     label: 'Failing' },
+  };
+
+  function renderIssue(issue) {
+    const sev = (issue.severity || 'medium').toLowerCase();
+    const sevClass = sev === 'critical' || sev === 'high'
+      ? 'bg-red-50 text-red-700'
+      : sev === 'medium' ? 'bg-amber-50 text-amber-700' : 'bg-gray-100 text-gray-700';
+    const msg = issue.message || issue.description || issue.type || 'Issue';
+    return `<li class="flex items-start gap-2">
+      <span class="mt-0.5 px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase ${sevClass}">${escapeHtml(sev)}</span>
+      <span class="text-sm text-gray-700 dark:text-gray-200">${escapeHtml(msg)}</span>
+    </li>`;
+  }
+
+  function renderRec(rec) {
+    const text = typeof rec === 'string'
+      ? rec
+      : (rec.message || rec.description || rec.recommendation || rec.suggestion || rec.type || '');
+    if (!text) return '';
+    return `<li class="flex items-start gap-2">
+      <span class="mt-0.5 text-emerald-600">✓</span>
+      <span class="text-sm text-gray-700 dark:text-gray-200">${escapeHtml(text)}</span>
+    </li>`;
+  }
+
+  function renderResult(d) {
+    const grade = (d.grade || 'F').toUpperCase();
+    const theme = GRADE_THEME[grade] || GRADE_THEME.F;
+    const issuesHtml = (d.issues_found || []).map(renderIssue).join('') || `<li class="text-sm text-gray-500">No issues detected — nice work.</li>`;
+    const recsHtml = (d.recommendations || []).map(renderRec).join('') || `<li class="text-sm text-gray-500">No further recommendations.</li>`;
+    const score = typeof d.score === 'number' ? d.score.toFixed(1) : d.score;
+    const upgradeHtml = d.show_upgrade_cta
+      ? `<div class="rounded-lg border border-indigo-200 bg-indigo-50 dark:bg-indigo-900/20 dark:border-indigo-800 p-4 flex items-start gap-3">
+           <span class="text-2xl">🎁</span>
+           <div class="flex-1 text-sm text-indigo-900 dark:text-indigo-200">
+             <strong>Only ${d.remaining} of ${d.cap} free grades left.</strong>
+             <a href="/register/" class="font-semibold underline">Sign up</a> for unlimited grading, AI rewrite suggestions, and history.
+           </div>
+         </div>`
+      : '';
+
+    resultPanel.innerHTML = `
+      <section class="bg-white dark:bg-[#161b22] rounded-xl border border-gray-200 dark:border-[#30363d] p-6 flex flex-col md:flex-row gap-6 shadow-sm">
+        <div class="flex-shrink-0 flex flex-col items-center justify-center text-center md:w-40 p-4 rounded-lg ring-1 ${theme.surface}">
+          <div class="text-6xl font-bold leading-none ${theme.text}">${escapeHtml(grade)}</div>
+          <div class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">${escapeHtml(score)}<span class="text-base text-gray-500">/100</span></div>
+          <div class="mt-1 text-xs uppercase tracking-wide text-gray-500">${theme.label}</div>
+        </div>
+        <div class="flex-1">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Summary</h2>
+          <dl class="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
+            <div><dt class="text-gray-500">Query type</dt><dd class="mt-0.5 font-medium text-gray-900 dark:text-white">${escapeHtml(d.query_type || '—')}</dd></div>
+            <div><dt class="text-gray-500">Complexity</dt><dd class="mt-0.5 font-medium text-gray-900 dark:text-white">${escapeHtml(d.complexity)}/100</dd></div>
+            <div><dt class="text-gray-500">Tables</dt><dd class="mt-0.5 font-medium text-gray-900 dark:text-white">${escapeHtml(d.table_count)}</dd></div>
+            <div><dt class="text-gray-500">Joins</dt><dd class="mt-0.5 font-medium text-gray-900 dark:text-white">${escapeHtml(d.join_count)}</dd></div>
+            <div><dt class="text-gray-500">Analysis time</dt><dd class="mt-0.5 font-medium text-gray-900 dark:text-white">${escapeHtml(d.execution_time_ms)}ms</dd></div>
+            <div><dt class="text-gray-500">Issues found</dt><dd class="mt-0.5 font-medium text-gray-900 dark:text-white">${(d.issues_found || []).length}</dd></div>
+          </dl>
+        </div>
+      </section>
+
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="bg-white dark:bg-[#161b22] rounded-xl border border-gray-200 dark:border-[#30363d] p-5">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Issues detected</h3>
+          <ul class="mt-3 space-y-2">${issuesHtml}</ul>
+        </div>
+        <div class="bg-white dark:bg-[#161b22] rounded-xl border border-gray-200 dark:border-[#30363d] p-5">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Recommendations</h3>
+          <ul class="mt-3 space-y-2">${recsHtml}</ul>
+        </div>
+      </section>
+
+      ${d.performance_notes ? `<section class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-4 text-sm text-amber-900 dark:text-amber-200">${escapeHtml(d.performance_notes)}</section>` : ''}
+
+      ${upgradeHtml}
+
+      <div class="flex flex-wrap gap-2 pt-1">
+        <a href="${escapeHtml(d.results_url)}" class="px-3 py-1.5 rounded border border-gray-300 dark:border-[#30363d] text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-[#21262d]">View full report</a>
+        <button type="button" id="gradeAgainBtn" class="px-3 py-1.5 rounded bg-indigo-600 text-white text-sm hover:bg-indigo-700">Grade another</button>
+      </div>
+    `;
+    resultPanel.classList.remove('hidden');
+
+    const again = document.getElementById('gradeAgainBtn');
+    if (again) {
+      again.addEventListener('click', () => {
+        resultPanel.classList.add('hidden');
+        sqlInput.value = '';
+        sqlInput.focus();
+        window.scrollTo({ top: form.offsetTop - 24, behavior: 'smooth' });
+      });
+    }
+
+    window.trackEvent('query_graded', {
+      grade: grade,
+      score: typeof d.score === 'number' ? d.score : parseFloat(d.score) || 0,
+      analysis_type: 'inline_anon'
+    });
+  }
+
+  function renderExhausted(d) {
+    resultPanel.innerHTML = `
+      <section class="bg-white dark:bg-[#161b22] rounded-xl border border-indigo-200 dark:border-indigo-900 p-8 text-center space-y-4 shadow-sm">
+        <div class="text-4xl">🚀</div>
+        <h2 class="text-2xl font-semibold text-gray-900 dark:text-white">You've used all ${d.cap} free trials</h2>
+        <p class="text-gray-600 dark:text-gray-300 max-w-xl mx-auto">Create a free account to keep grading queries — plus unlock AI rewrite suggestions, personalized feedback, query history, and saved reports.</p>
+        <div class="flex gap-3 justify-center pt-2">
+          <a href="${escapeHtml(d.register_url)}" class="px-6 py-2.5 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700">Create free account</a>
+          <a href="${escapeHtml(d.login_url)}" class="px-6 py-2.5 border border-gray-300 dark:border-[#30363d] text-gray-700 dark:text-gray-200 text-sm font-medium rounded-md hover:bg-gray-50 dark:hover:bg-[#21262d]">Log in</a>
+        </div>
+      </section>
+    `;
+    resultPanel.classList.remove('hidden');
+    submitBtn.disabled = true;
+    window.trackEvent('trial_exhausted', { trial_cap: d.cap, queries_used: d.cap });
+  }
+
+  function renderErrors(errors) {
+    const sqlErrs = errors && errors.sql_query;
+    if (sqlErrs && sqlErrs.length) {
+      sqlError.textContent = sqlErrs.map(e => e.message || e).join(' ');
+      sqlError.classList.remove('hidden');
+    } else {
+      sqlError.textContent = 'Please check your query and try again.';
+      sqlError.classList.remove('hidden');
+    }
+  }
+
+  function updateCreditsPill(remaining) {
+    const el = document.querySelector('[data-anon-credits]');
+    if (el && typeof remaining === 'number') el.textContent = remaining;
+  }
+
+  async function submitQuery(e) {
+    e.preventDefault();
+    sqlError.classList.add('hidden');
+    resultPanel.classList.add('hidden');
+
+    const sql = (sqlInput.value || '').trim();
+    if (!sql) {
+      sqlError.textContent = 'Please paste a SQL query first.';
+      sqlError.classList.remove('hidden');
+      sqlInput.focus();
+      return;
+    }
+
+    submitBtn.disabled = true;
+    startStaged();
+
+    try {
+      const fd = new FormData(form);
+      const resp = await fetch('{% url "grade_query_ajax" %}', {
+        method: 'POST',
+        headers: { 'X-CSRFToken': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
+        body: fd,
+        credentials: 'same-origin',
+      });
+
+      let data = {};
+      try { data = await resp.json(); } catch (e) { /* non-JSON error */ }
+
+      finishStaged();
+
+      if (resp.status === 429) {
+        showToast('Too many requests. Slow down a moment and try again.', 'error');
+        return;
+      }
+
+      if (data.status === 'trial_exhausted') {
+        renderExhausted(data);
+        updateCreditsPill(0);
+        return;
+      }
+      if (data.status === 'invalid') {
+        renderErrors(data.errors);
+        return;
+      }
+      if (data.status === 'ok') {
+        updateCreditsPill(data.remaining);
+        renderResult(data);
+        return;
+      }
+      showToast(data.message || 'Analysis failed. Please try again.', 'error');
+    } catch (err) {
+      finishStaged();
+      showToast('Network error. Please try again.', 'error');
+    } finally {
+      submitBtn.disabled = false;
+    }
+  }
+
+  form.addEventListener('submit', submitQuery);
+  sqlInput.addEventListener('keydown', function(e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      submitQuery(e);
+    }
+  });
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/analyzer/test_anonymous_trial.py
+++ b/analyzer/test_anonymous_trial.py
@@ -62,12 +62,13 @@ class AnonymousTrialTestCase(TransactionTestCase):
     # ---------- Landing & form rendering ----------
 
     def test_anon_landing_renders_inline_grade_form(self):
-        """GET / for anon shows the inline grade form + trial banner."""
+        """GET / for anon shows the minimalist inline grade form + trial counter."""
         response = self.client.get(reverse("index"))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Try QueryGrade free")
-        self.assertContains(response, "3 of 3 grades left")
-        self.assertContains(response, "Create free account")
+        self.assertContains(response, "Grade any SQL query in seconds")
+        self.assertContains(response, "inlineGradeForm")
+        self.assertContains(response, "3 of 3 free grades remaining")
+        self.assertContains(response, "How QueryGrade works")
 
     def test_anon_grade_page_shows_trial_banner(self):
         """GET /grade/ for anon shows the trial banner and form."""

--- a/analyzer/urls.py
+++ b/analyzer/urls.py
@@ -16,7 +16,7 @@ from .views import (  # Authentication views; Query grading views; Comparison vi
     check_task_status, compare_results, connection_create, connection_delete,
     connection_edit, connection_test, connections_list, contextualized_results,
     database_analyze, database_schema, enhanced_grade_results,
-    feedback_analytics, grade_query, grade_results, index, login_view,
+    feedback_analytics, grade_query, grade_query_ajax, grade_results, index, login_view,
     logout_view, password_change, password_reset_confirm,
     password_reset_request, performance_report_view, query_compare,
     query_history, query_with_context, quick_feedback, register_view,
@@ -28,6 +28,7 @@ urlpatterns = [
     path("analyze/", analyze, name="analyze"),
     # Query grading
     path("grade/", grade_query, name="grade_query"),
+    path("grade/ajax/", grade_query_ajax, name="grade_query_ajax"),
     path("grade/results/<int:analysis_id>/", grade_results, name="grade_results"),
     path(
         "grade/enhanced/<int:analysis_id>/",

--- a/analyzer/views/__init__.py
+++ b/analyzer/views/__init__.py
@@ -37,7 +37,8 @@ from .history_views import query_history
 # Query grading views
 from .query_grading_views import (batch_grade_queries, batch_results,
                                   compare_queries, enhanced_grade_results,
-                                  grade_query, grade_results)
+                                  grade_query, grade_query_ajax,
+                                  grade_results)
 # Upload and async processing views
 from .upload_views import (analyze, async_processing_status, async_results,
                            check_task_status, index)
@@ -58,6 +59,7 @@ __all__ = [
     "account_view",
     # Grading
     "grade_query",
+    "grade_query_ajax",
     "grade_results",
     "enhanced_grade_results",
     "compare_queries",

--- a/analyzer/views/query_grading_views.py
+++ b/analyzer/views/query_grading_views.py
@@ -316,14 +316,22 @@ def grade_query_ajax(request):
 
     Returns JSON. Mirrors the anon branch of ``grade_query``: enforces the trial
     cap, tracks analysis IDs in the session so ``/grade/results/<id>/`` keeps
-    working for a "View full report" link, but never redirects. Authenticated
-    users may also use it for the same inline flow (no ML enhancement here —
-    that still lives at /grade/).
+    working for a "View full report" link, but never redirects.
+
+    Anonymous-only — authenticated users have the full /grade/ flow (which
+    creates UserQueryHistory and runs ML enhancement). Routing auth users
+    through this endpoint would create analyses with no UserQueryHistory row,
+    which ``grade_results`` then rejects with "permission denied".
     """
-    is_anon = not request.user.is_authenticated
+    if request.user.is_authenticated:
+        return JsonResponse(
+            {"status": "auth_required_redirect", "redirect": reverse("grade_query")},
+            status=403,
+        )
+
     cap, count, remaining = anon_trial_state(request)
 
-    if is_anon and remaining <= 0:
+    if remaining <= 0:
         return JsonResponse(
             {
                 "status": "trial_exhausted",
@@ -351,25 +359,21 @@ def grade_query_ajax(request):
             status=400,
         )
     except Exception as e:
-        who = "anonymous" if is_anon else request.user.username
-        logger.error("Unexpected error in grade_query_ajax for %s: %s", who, e)
+        logger.error("Unexpected error in grade_query_ajax for anonymous: %s", e)
         return JsonResponse(
             {"status": "error", "message": "Analysis failed. Please try again."},
             status=500,
         )
 
-    if is_anon:
-        ids = list(request.session.get(ANON_ANALYSIS_SESSION_KEY, []))
-        ids.append(analysis.id)
-        request.session[ANON_ANALYSIS_SESSION_KEY] = ids[-ANON_ANALYSIS_HISTORY_LIMIT:]
-        new_count = count + 1
-        request.session[ANON_TRIAL_COUNT_KEY] = new_count
-        request.session.modified = True
-        new_remaining = max(cap - new_count, 0)
-    else:
-        new_remaining = remaining
+    ids = list(request.session.get(ANON_ANALYSIS_SESSION_KEY, []))
+    ids.append(analysis.id)
+    request.session[ANON_ANALYSIS_SESSION_KEY] = ids[-ANON_ANALYSIS_HISTORY_LIMIT:]
+    new_count = count + 1
+    request.session[ANON_TRIAL_COUNT_KEY] = new_count
+    request.session.modified = True
+    new_remaining = max(cap - new_count, 0)
 
-    show_upgrade_cta = is_anon and new_remaining <= 10
+    show_upgrade_cta = new_remaining <= 10
 
     return JsonResponse(
         {
@@ -388,7 +392,7 @@ def grade_query_ajax(request):
             "remaining": new_remaining,
             "cap": cap,
             "show_upgrade_cta": show_upgrade_cta,
-            "is_anonymous": is_anon,
+            "is_anonymous": True,
             "results_url": reverse("grade_results", args=[analysis.id]),
         }
     )

--- a/analyzer/views/query_grading_views.py
+++ b/analyzer/views/query_grading_views.py
@@ -16,7 +16,10 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
+from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
+from django.views.decorators.http import require_POST
 from django_ratelimit.decorators import ratelimit
 
 from ..db_versions import DATABASE_VERSIONS
@@ -300,6 +303,94 @@ def grade_query(request):
             "trial_remaining": remaining,
             "db_versions": DATABASE_VERSIONS,
         },
+    )
+
+
+@transaction.non_atomic_requests
+@require_POST
+@ratelimit(key=_anon_ip_key, rate=ANON_QUERY_RATE_LIMIT, method="POST", block=True)
+@ratelimit(key="user", rate=QUERY_RATE_LIMIT, method="POST", block=True)
+def grade_query_ajax(request):
+    """
+    AJAX endpoint backing the inline grading flow on the anonymous landing page.
+
+    Returns JSON. Mirrors the anon branch of ``grade_query``: enforces the trial
+    cap, tracks analysis IDs in the session so ``/grade/results/<id>/`` keeps
+    working for a "View full report" link, but never redirects. Authenticated
+    users may also use it for the same inline flow (no ML enhancement here —
+    that still lives at /grade/).
+    """
+    is_anon = not request.user.is_authenticated
+    cap, count, remaining = anon_trial_state(request)
+
+    if is_anon and remaining <= 0:
+        return JsonResponse(
+            {
+                "status": "trial_exhausted",
+                "cap": cap,
+                "remaining": 0,
+                "register_url": reverse("register"),
+                "login_url": reverse("login"),
+            }
+        )
+
+    form = QueryGradeForm(request.POST, user=request.user)
+    if not form.is_valid():
+        return JsonResponse(
+            {"status": "invalid", "errors": form.errors.get_json_data()}, status=400
+        )
+
+    sql_query = form.cleaned_data["sql_query"]
+    database_type = form.cleaned_data.get("database_type", "")
+
+    try:
+        query, analysis = analyze_query(sql_query, database_type)
+    except ValueError as e:
+        return JsonResponse(
+            {"status": "invalid", "errors": {"sql_query": [{"message": str(e)}]}},
+            status=400,
+        )
+    except Exception as e:
+        who = "anonymous" if is_anon else request.user.username
+        logger.error("Unexpected error in grade_query_ajax for %s: %s", who, e)
+        return JsonResponse(
+            {"status": "error", "message": "Analysis failed. Please try again."},
+            status=500,
+        )
+
+    if is_anon:
+        ids = list(request.session.get(ANON_ANALYSIS_SESSION_KEY, []))
+        ids.append(analysis.id)
+        request.session[ANON_ANALYSIS_SESSION_KEY] = ids[-ANON_ANALYSIS_HISTORY_LIMIT:]
+        new_count = count + 1
+        request.session[ANON_TRIAL_COUNT_KEY] = new_count
+        request.session.modified = True
+        new_remaining = max(cap - new_count, 0)
+    else:
+        new_remaining = remaining
+
+    show_upgrade_cta = is_anon and new_remaining <= 10
+
+    return JsonResponse(
+        {
+            "status": "ok",
+            "analysis_id": analysis.id,
+            "grade": analysis.grade,
+            "score": float(analysis.score),
+            "query_type": query.query_type,
+            "complexity": query.estimated_complexity,
+            "table_count": query.table_count,
+            "join_count": query.join_count,
+            "execution_time_ms": analysis.execution_time_ms,
+            "issues_found": analysis.issues_found or [],
+            "recommendations": analysis.recommendations or [],
+            "performance_notes": analysis.performance_notes or "",
+            "remaining": new_remaining,
+            "cap": cap,
+            "show_upgrade_cta": show_upgrade_cta,
+            "is_anonymous": is_anon,
+            "results_url": reverse("grade_results", args=[analysis.id]),
+        }
     )
 
 


### PR DESCRIPTION
## Summary
- Replace the dashboard-style anonymous landing at `/` with a single-purpose grader: minimalist SQL textarea, staged 4-step progress bar, and the full grade pill / issues / recommendations rendered inline (no redirect). Authenticated users keep the existing dashboard.
- New `POST /grade/ajax/` JSON endpoint mirrors the anon branch of `grade_query` — enforces the trial cap, tracks analysis IDs in the session so `/grade/results/<id>/` still serves the "View full report" link, and is guarded by the same anon-IP + per-user rate limits.
- Prominent "How QueryGrade works" section explains rule-based grading (9 analyzers, 18+ issue types, 27+ recommendation types), ML refinement (hybrid scoring), and how user feedback continuously improves the model.
- Navbar credits pill updates in-place via `[data-anon-credits]` after each AJAX grade. GA4 fires `query_graded` (`analysis_type: inline_anon`) on success and `trial_exhausted` on cap hit.

## Test plan
- [x] `GET /` (anon) renders the new hero, `inlineGradeForm`, and "How QueryGrade works" cards
- [x] `POST /grade/ajax/` returns JSON `{status: ok, grade, score, issues_found, recommendations, remaining, results_url}` and decrements the session trial counter
- [x] `POST /grade/ajax/` with `anon_trial_count=50` returns `{status: trial_exhausted, cap, register_url, login_url}` without creating an analysis
- [x] `POST /grade/ajax/` with empty SQL returns 400 `{status: invalid, errors}`
- [x] `GET /` for an authenticated user still renders the original dashboard (Welcome back / Quick Grade cards, no `inlineGradeForm`)
- [x] `python manage.py test analyzer.test_anonymous_trial` — 9/10 pass; the one remaining failure (`test_anon_grade_page_shows_trial_banner` on `/grade/`) is on the pre-existing list documented in `CLAUDE.md` and untouched by this PR
- [ ] Manual: load `/` in incognito, paste a query, confirm the staged progress bar runs (Parse → Analyze clauses → Check indexes → Score) and results appear inline with the navbar credits pill decrementing
- [ ] Manual: confirm "View full report" link opens `/grade/results/<id>/` in the same session