### PR TITLE
feat(ui): rework dark-mode palette to near-OLED (Dark-Reader-inspired)

### DIFF
--- a/analyzer/static/analyzer/css/dark-mode.css
+++ b/analyzer/static/analyzer/css/dark-mode.css
@@ -37,16 +37,16 @@ html.dark {
   --qg-ink:       #e5e7eb;
   --qg-ink-muted: #94a3b8;
 
-  --bg-base:     #0d1117;
-  --bg-surface:  #161b22;
-  --bg-elevated: #21262d;
-  --bg-hover:    #2d333b;
+  --bg-base:     #0a0a0a;
+  --bg-surface:  #111113;
+  --bg-elevated: #17181c;
+  --bg-hover:    #25272d;
 
-  --border:      #30363d;
-  --border-muted:#21262d;
+  --border:      #1f1f23;
+  --border-muted:#17181c;
   --border-focus: #818cf8;
 
-  --text-primary:   #e6edf3;
+  --text-primary:   #e7e5e0;
   --text-secondary: #8b949e;
   --text-muted:     #6e7681;
   --text-link:      #a5b4fc;
@@ -61,14 +61,14 @@ html.dark {
 }
 
 /* ─── Background scale ─── */
-html.dark .bg-white         { background-color: #161b22; }
-html.dark .bg-gray-50       { background-color: #0d1117; }
-html.dark .bg-gray-100      { background-color: #21262d; }
-html.dark .bg-gray-200      { background-color: #2d333b; }
+html.dark .bg-white         { background-color: #111113; }
+html.dark .bg-gray-50       { background-color: #0a0a0a; }
+html.dark .bg-gray-100      { background-color: #17181c; }
+html.dark .bg-gray-200      { background-color: #25272d; }
 
 /* ─── Text scale ─── */
-html.dark .text-gray-950    { color: #e6edf3; }
-html.dark .text-gray-900    { color: #e6edf3; }
+html.dark .text-gray-950    { color: #e7e5e0; }
+html.dark .text-gray-900    { color: #e7e5e0; }
 html.dark .text-gray-800    { color: #cdd9e5; }
 html.dark .text-gray-700    { color: #adbac7; }
 html.dark .text-gray-600    { color: #8b949e; }
@@ -76,8 +76,8 @@ html.dark .text-gray-500    { color: #8b949e; }  /* was #6e7681, below WCAG AA o
 html.dark .text-gray-400    { color: #6e7681; }
 
 /* ─── Borders ─── */
-html.dark .border-gray-100  { border-color: #21262d; }
-html.dark .border-gray-200  { border-color: #30363d; }
+html.dark .border-gray-100  { border-color: #17181c; }
+html.dark .border-gray-200  { border-color: #1f1f23; }
 html.dark .border-gray-300  { border-color: #444c56; }
 
 /* ─── Shadows ─── */
@@ -103,9 +103,9 @@ html.dark .from-indigo-50 {
   --tw-gradient-to: rgba(129, 140, 248, 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
-html.dark .to-white      { --tw-gradient-to: #161b22 var(--tw-gradient-to-position); }
+html.dark .to-white      { --tw-gradient-to: #111113 var(--tw-gradient-to-position); }
 html.dark .from-white    {
-  --tw-gradient-from: #161b22 var(--tw-gradient-from-position);
+  --tw-gradient-from: #111113 var(--tw-gradient-from-position);
   --tw-gradient-to: rgba(22, 27, 34, 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
@@ -155,9 +155,9 @@ html.dark .text-orange-700  { color: #fb923c; }
 /* ─── Navbar credits pill — handled by the grade-pill compound rules above ─── */
 
 /* ─── Hover utility overrides ─── */
-html.dark .hover\:bg-gray-100:hover { background-color: #21262d; }
-html.dark .hover\:bg-gray-50:hover  { background-color: #21262d; }
-html.dark .hover\:text-gray-900:hover { color: #e6edf3; }
+html.dark .hover\:bg-gray-100:hover { background-color: #17181c; }
+html.dark .hover\:bg-gray-50:hover  { background-color: #17181c; }
+html.dark .hover\:text-gray-900:hover { color: #e7e5e0; }
 html.dark .hover\:bg-red-50:hover   { background-color: rgba(220,38,38,0.12); }
 
 /* ─── Dropdown menus ─── */
@@ -168,9 +168,9 @@ html.dark .ring-opacity-5           { --tw-ring-opacity: 1; }
 html.dark input:not([type=checkbox]):not([type=radio]):not([type=submit]):not([type=button]):not([type=range]),
 html.dark select,
 html.dark textarea {
-  background-color: #0d1117;
-  border-color: #30363d;
-  color: #e6edf3;
+  background-color: #0a0a0a;
+  border-color: #1f1f23;
+  color: #e7e5e0;
   color-scheme: dark;
 }
 html.dark input::placeholder,
@@ -187,21 +187,21 @@ html.dark textarea:focus {
 /* ─── Code / pre ─── */
 html.dark pre,
 html.dark code {
-  background-color: #161b22;
-  border-color: #30363d;
-  color: #e6edf3;
+  background-color: #111113;
+  border-color: #1f1f23;
+  color: #e7e5e0;
 }
 
 /* ─── Table ─── */
-html.dark table { border-color: #30363d; }
-html.dark thead { background-color: #161b22; }
-html.dark tbody tr:hover { background-color: #21262d; }
-html.dark th, html.dark td { border-color: #30363d; color: #e6edf3; }
+html.dark table { border-color: #1f1f23; }
+html.dark thead { background-color: #111113; }
+html.dark tbody tr:hover { background-color: #17181c; }
+html.dark th, html.dark td { border-color: #1f1f23; color: #e7e5e0; }
 
 /* ─── Scrollbars (Chromium) ─── */
 html.dark ::-webkit-scrollbar { width: 8px; height: 8px; }
-html.dark ::-webkit-scrollbar-track { background: #0d1117; }
-html.dark ::-webkit-scrollbar-thumb { background: #30363d; border-radius: 4px; }
+html.dark ::-webkit-scrollbar-track { background: #0a0a0a; }
+html.dark ::-webkit-scrollbar-thumb { background: #1f1f23; border-radius: 4px; }
 html.dark ::-webkit-scrollbar-thumb:hover { background: #444c56; }
 
 /* ─── CodeMirror — theme is toggled via window.QG.cmTheme() in base.html ─── */
@@ -231,8 +231,8 @@ html.dark .theme-toggle {
   color: #8b949e;
 }
 html.dark .theme-toggle:hover {
-  background-color: #21262d;
-  color: #e6edf3;
+  background-color: #17181c;
+  color: #e7e5e0;
 }
 .theme-toggle .icon-moon { display: block; }
 .theme-toggle .icon-sun  { display: none; }
@@ -244,14 +244,14 @@ html.dark .theme-toggle .icon-sun  { display: block; }
 /* the selected DB chip relies on Tailwind dark:bg-white / dark:text-slate-900 */
 /* to invert in dark mode; an override at this level loses to dark: variants */
 /* only by source order, which would silently invert the chip back to dark. */
-html.dark .bg-slate-100        { background-color: #21262d; }
-html.dark .bg-slate-800        { background-color: #21262d; }
+html.dark .bg-slate-100        { background-color: #17181c; }
+html.dark .bg-slate-800        { background-color: #17181c; }
 html.dark .text-slate-200      { color: #adbac7; }
 html.dark .text-slate-300      { color: #adbac7; }
 html.dark .text-slate-600      { color: #8b949e; }
 html.dark .text-slate-700      { color: #cdd9e5; }
-html.dark .hover\:bg-slate-200:hover { background-color: #2d333b; }
-html.dark .hover\:bg-slate-700:hover { background-color: #2d333b; }
+html.dark .hover\:bg-slate-200:hover { background-color: #25272d; }
+html.dark .hover\:bg-slate-700:hover { background-color: #25272d; }
 
 /* ─── Indeterminate loading bar (honest loading copy in anon path) ─── */
 @keyframes qg-indeterminate-slide {
@@ -340,9 +340,9 @@ dialog#qg-shortcuts-dialog::backdrop {
   backdrop-filter: blur(2px);
 }
 html.dark dialog#qg-shortcuts-dialog {
-  background: #161b22;
-  color: #e6edf3;
-  border-color: #30363d;
+  background: #111113;
+  color: #e7e5e0;
+  border-color: #1f1f23;
   box-shadow: 0 20px 40px -5px rgba(0,0,0,0.7);
 }
 html.dark dialog#qg-shortcuts-dialog::backdrop {

--- a/analyzer/templates/analyzer/base.html
+++ b/analyzer/templates/analyzer/base.html
@@ -78,11 +78,11 @@
   {% endif %}
   {% endif %}
 </head>
-<body class="bg-gray-50 dark:bg-[#0d1117] dark:text-[#e6edf3] min-h-screen flex flex-col">
+<body class="bg-gray-50 dark:bg-[#0a0a0a] dark:text-[#e7e5e0] min-h-screen flex flex-col">
 
-  <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-indigo-600 text-white px-3 py-2 rounded z-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-indigo-500">Skip to main content</a>
+  <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-indigo-600 text-white px-3 py-2 rounded z-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-indigo-500">Skip to main content</a>
 
-  <nav class="bg-white dark:bg-[#161b22] border-b border-gray-200 dark:border-[#30363d] shadow-sm dark:shadow-none" id="navigation">
+  <nav class="bg-white dark:bg-[#111113] border-b border-gray-200 dark:border-[#1f1f23] shadow-sm dark:shadow-none" id="navigation">
     <div class="max-w-7xl mx-auto px-4 sm:px-6">
       <div class="flex items-center justify-between h-14">
         <a href="{% url 'index' %}" class="flex items-center gap-2 font-mono font-semibold text-indigo-600 dark:text-[#a5b4fc] text-lg tracking-tight" aria-label="QueryGrade home">
@@ -97,7 +97,7 @@
           {% if user.is_authenticated %}
             <button type="button" id="qg-mobile-nav-toggle"
                     aria-expanded="false" aria-controls="qg-mobile-nav" aria-label="Open navigation"
-                    class="md:hidden inline-flex items-center justify-center w-9 h-9 rounded text-gray-600 dark:text-[#adbac7] hover:bg-gray-100 dark:hover:bg-[#21262d] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-indigo-500">
+                    class="md:hidden inline-flex items-center justify-center w-9 h-9 rounded text-gray-600 dark:text-[#adbac7] hover:bg-gray-100 dark:hover:bg-[#17181c] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-indigo-500">
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
             </button>
             <div class="hidden md:flex gap-1 items-center">
@@ -130,16 +130,16 @@
                       aria-haspopup="true"
                       aria-expanded="false"
                       aria-controls="user-menu"
-                      class="px-3 py-1.5 rounded text-sm font-medium text-gray-700 dark:text-[#adbac7] hover:bg-gray-100 dark:hover:bg-[#21262d] flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-indigo-500">
+                      class="px-3 py-1.5 rounded text-sm font-medium text-gray-700 dark:text-[#adbac7] hover:bg-gray-100 dark:hover:bg-[#17181c] flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-indigo-500">
                 {{ user.username }}
                 <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"/></svg>
               </button>
               <div id="user-menu" role="menu" aria-labelledby="user-menu-button"
-                   class="hidden absolute right-0 mt-1 w-48 bg-white dark:bg-[#161b22] rounded-md shadow-lg dark:shadow-[0_4px_12px_rgba(0,0,0,0.5)] ring-1 ring-black ring-opacity-5 dark:ring-[#30363d] dark:ring-opacity-100 z-50">
-                <a href="{% url 'account' %}" role="menuitem" class="block px-4 py-2 text-sm text-gray-700 dark:text-[#adbac7] hover:bg-gray-50 dark:hover:bg-[#21262d]">My Account</a>
-                <a href="{% url 'connections_list' %}" role="menuitem" class="block px-4 py-2 text-sm text-gray-700 dark:text-[#adbac7] hover:bg-gray-50 dark:hover:bg-[#21262d]">Database Connections</a>
-                <a href="{% url 'password_change' %}" role="menuitem" class="block px-4 py-2 text-sm text-gray-700 dark:text-[#adbac7] hover:bg-gray-50 dark:hover:bg-[#21262d]">Change Password</a>
-                <div class="border-t border-gray-100 dark:border-[#30363d]"></div>
+                   class="hidden absolute right-0 mt-1 w-48 bg-white dark:bg-[#111113] rounded-md shadow-lg dark:shadow-[0_4px_12px_rgba(0,0,0,0.5)] ring-1 ring-black ring-opacity-5 dark:ring-[#1f1f23] dark:ring-opacity-100 z-50">
+                <a href="{% url 'account' %}" role="menuitem" class="block px-4 py-2 text-sm text-gray-700 dark:text-[#adbac7] hover:bg-gray-50 dark:hover:bg-[#17181c]">My Account</a>
+                <a href="{% url 'connections_list' %}" role="menuitem" class="block px-4 py-2 text-sm text-gray-700 dark:text-[#adbac7] hover:bg-gray-50 dark:hover:bg-[#17181c]">Database Connections</a>
+                <a href="{% url 'password_change' %}" role="menuitem" class="block px-4 py-2 text-sm text-gray-700 dark:text-[#adbac7] hover:bg-gray-50 dark:hover:bg-[#17181c]">Change Password</a>
+                <div class="border-t border-gray-100 dark:border-[#1f1f23]"></div>
                 <a href="{% url 'logout' %}" role="menuitem" class="block px-4 py-2 text-sm text-red-600 dark:text-[#f87171] hover:bg-red-50 dark:hover:bg-[rgba(220,38,38,0.1)]">Logout</a>
               </div>
             </div>
@@ -177,20 +177,20 @@
     </div>
     {% if user.is_authenticated %}
     {% with url_name=request.resolver_match.url_name %}
-    <div id="qg-mobile-nav" class="hidden md:hidden border-t border-gray-200 dark:border-[#30363d] bg-white dark:bg-[#161b22]">
+    <div id="qg-mobile-nav" class="hidden md:hidden border-t border-gray-200 dark:border-[#1f1f23] bg-white dark:bg-[#111113]">
       <a href="{% url 'index' %}" data-nav="dashboard"
-         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'index' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#21262d]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">Dashboard</a>
+         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'index' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#17181c]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">Dashboard</a>
       <a href="{% url 'grade_query' %}" data-nav="grade"
-         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'grade_query' or url_name == 'grade_results' or url_name == 'enhanced_grade_results' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#21262d]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">Grade</a>
+         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'grade_query' or url_name == 'grade_results' or url_name == 'enhanced_grade_results' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#17181c]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">Grade</a>
       <a href="{% url 'batch_analysis' %}" data-nav="batch"
-         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'batch_analysis' or url_name == 'batch_results' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#21262d]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">Batch</a>
+         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'batch_analysis' or url_name == 'batch_results' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#17181c]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">Batch</a>
       <a href="{% url 'database_analyze' %}" data-nav="database"
-         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'database_analyze' or url_name == 'database_schema' or url_name == 'query_with_context' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#21262d]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">Database</a>
+         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'database_analyze' or url_name == 'database_schema' or url_name == 'query_with_context' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#17181c]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">Database</a>
       <a href="{% url 'query_history' %}" data-nav="history"
-         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'query_history' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#21262d]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">History</a>
+         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'query_history' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#17181c]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">History</a>
       {% if user.is_staff %}
       <a href="{% url 'ml_dashboard' %}" data-nav="ml"
-         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'ml_dashboard' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#21262d]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">ML</a>
+         class="block px-4 py-3 text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800 {% if url_name == 'ml_dashboard' %}text-indigo-700 dark:text-[#a5b4fc] bg-indigo-50 dark:bg-[#17181c]{% else %}text-gray-700 dark:text-[#adbac7]{% endif %}">ML</a>
       {% endif %}
     </div>
     {% endwith %}
@@ -216,7 +216,7 @@
     {% block content %}{% endblock %}
   </main>
 
-  <footer class="bg-white dark:bg-[#161b22] border-t border-slate-200 dark:border-slate-700 mt-auto">
+  <footer class="bg-white dark:bg-[#111113] border-t border-slate-200 dark:border-slate-700 mt-auto">
     <div class="max-w-7xl mx-auto flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 sm:px-6 py-6 text-sm text-slate-600 dark:text-slate-400">
       <div class="flex items-center gap-2">
         <span class="font-mono font-semibold text-slate-700 dark:text-slate-200">QueryGrade</span>
@@ -379,7 +379,7 @@
 
     // Apply Tailwind-friendly classes to Django-rendered form widgets that don't already have a `class` attr
     document.addEventListener('DOMContentLoaded', () => {
-      const inputClasses = 'w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 text-sm bg-white text-gray-900 dark:bg-[#0d1117] dark:border-[#30363d] dark:text-[#e6edf3] dark:focus:border-[#818cf8]';
+      const inputClasses = 'w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 text-sm bg-white text-gray-900 dark:bg-[#0a0a0a] dark:border-[#1f1f23] dark:text-[#e7e5e0] dark:focus:border-[#818cf8]';
       document.querySelectorAll('form input:not([type=hidden]):not([type=checkbox]):not([type=radio]):not([type=submit]):not([type=button]):not([type=file]), form select, form textarea').forEach(el => {
         if (!el.className.trim()) el.className = inputClasses;
       });

--- a/analyzer/templates/analyzer/grade_form.html
+++ b/analyzer/templates/analyzer/grade_form.html
@@ -39,7 +39,7 @@
     <p class="text-sm text-gray-600 max-w-lg mx-auto">Create a free account to keep grading queries — plus unlock AI rewrite suggestions, personalized feedback, query history, and saved reports.</p>
     <div class="flex flex-col items-center gap-3 pt-2">
       <a href="{% url 'register' %}"
-         class="inline-flex items-center justify-center px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold rounded-md min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-emerald-500">
+         class="inline-flex items-center justify-center px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold rounded-md min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-emerald-500">
         Create account
       </a>
       <a href="{% url 'login' %}" class="text-sm text-slate-600 dark:text-slate-300 hover:underline">Already have an account? Log in</a>
@@ -225,14 +225,14 @@
       <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Speed up query analysis with these keys.</p>
       <table class="mt-4 w-full text-sm">
         <thead class="sr-only"><tr><th>Key</th><th>Action</th></tr></thead>
-        <tbody class="divide-y divide-gray-200 dark:divide-[#30363d]">
-          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">Cmd/Ctrl</kbd> + <kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">Enter</kbd></td><td class="py-2">Grade query</td></tr>
-          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">Cmd/Ctrl</kbd> + <kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">Space</kbd></td><td class="py-2">Autocomplete</td></tr>
-          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">Cmd/Ctrl</kbd> + <kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">/</kbd></td><td class="py-2">Toggle comment</td></tr>
-          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">F11</kbd></td><td class="py-2">Toggle fullscreen editor</td></tr>
-          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">Tab</kbd> / <kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">Shift</kbd>+<kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">Tab</kbd></td><td class="py-2">Indent / unindent</td></tr>
-          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">Esc</kbd></td><td class="py-2">Exit fullscreen / close this dialog</td></tr>
-          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] bg-gray-50 dark:bg-[#0d1117] font-mono text-xs">?</kbd></td><td class="py-2">Open this shortcuts dialog</td></tr>
+        <tbody class="divide-y divide-gray-200 dark:divide-[#1f1f23]">
+          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">Cmd/Ctrl</kbd> + <kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">Enter</kbd></td><td class="py-2">Grade query</td></tr>
+          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">Cmd/Ctrl</kbd> + <kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">Space</kbd></td><td class="py-2">Autocomplete</td></tr>
+          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">Cmd/Ctrl</kbd> + <kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">/</kbd></td><td class="py-2">Toggle comment</td></tr>
+          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">F11</kbd></td><td class="py-2">Toggle fullscreen editor</td></tr>
+          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">Tab</kbd> / <kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">Shift</kbd>+<kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">Tab</kbd></td><td class="py-2">Indent / unindent</td></tr>
+          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">Esc</kbd></td><td class="py-2">Exit fullscreen / close this dialog</td></tr>
+          <tr><td class="py-2 pr-4"><kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] bg-gray-50 dark:bg-[#0a0a0a] font-mono text-xs">?</kbd></td><td class="py-2">Open this shortcuts dialog</td></tr>
         </tbody>
       </table>
       <div class="mt-5 flex justify-end">

--- a/analyzer/templates/analyzer/grade_results.html
+++ b/analyzer/templates/analyzer/grade_results.html
@@ -29,7 +29,7 @@
     </div>
     <div class="flex flex-wrap items-center gap-3 text-sm">
       <a href="{% url 'grade_query' %}"
-         class="inline-flex items-center justify-center px-5 py-3 rounded-md bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-indigo-500">
+         class="inline-flex items-center justify-center px-5 py-3 rounded-md bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-indigo-500">
         Grade another query →
       </a>
       {% if is_anonymous %}
@@ -63,7 +63,7 @@
   {% endif %}
 
   {# Top-issue hero (populated by JS) #}
-  <section id="top-issue-hero" class="qg-anchor-target bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-6" hidden>
+  <section id="top-issue-hero" class="qg-anchor-target bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-6" hidden>
     <div class="flex items-center gap-2 text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-2">
       <span class="font-semibold">Top issue</span>
       <span aria-hidden="true">·</span>
@@ -80,16 +80,16 @@
       <textarea class="sql-display" id="top-issue-sql">{{ query.sql_text }}</textarea>
     </div>
 
-    <div id="top-issue-fix" class="mt-5 border-t border-gray-100 dark:border-[#21262d] pt-4 hidden">
+    <div id="top-issue-fix" class="mt-5 border-t border-gray-100 dark:border-[#17181c] pt-4 hidden">
       <div class="text-xs font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-400 mb-1.5">Suggested fix</div>
       <p id="top-issue-fix-text" class="text-sm text-slate-800 dark:text-slate-200"></p>
       <div class="mt-3 flex flex-wrap items-center gap-2">
         <a id="top-issue-fix-link" href="#"
-           class="inline-flex items-center justify-center px-3 py-2 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-emerald-500">
+           class="inline-flex items-center justify-center px-3 py-2 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-emerald-500">
           Show rewrite ↓
         </a>
         <button type="button" id="top-issue-copy-btn"
-           class="inline-flex items-center justify-center px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 text-sm font-medium min-h-[44px] hover:bg-slate-50 dark:hover:bg-[#21262d] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-indigo-500">
+           class="inline-flex items-center justify-center px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 text-sm font-medium min-h-[44px] hover:bg-slate-50 dark:hover:bg-[#17181c] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-indigo-500">
           Copy fix
         </button>
       </div>
@@ -97,23 +97,23 @@
   </section>
 
   {# Empty state #}
-  <section id="no-issues-state" class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-6 text-center" hidden>
+  <section id="no-issues-state" class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-6 text-center" hidden>
     <div class="text-3xl mb-2" aria-hidden="true">✨</div>
     <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Nothing to fix.</h2>
     <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">This query already follows the patterns we look for.</p>
   </section>
 
   {# Other issues feed #}
-  <section id="other-issues-section" class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5" hidden>
+  <section id="other-issues-section" class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5" hidden>
     <h3 class="text-base font-semibold text-gray-900 dark:text-white flex items-center gap-2">
       <span>Other issues</span>
       <span id="other-issues-count" class="text-xs font-normal text-slate-500 dark:text-slate-400"></span>
     </h3>
-    <ul id="other-issues-list" role="list" class="mt-3 divide-y divide-gray-100 dark:divide-[#21262d]"></ul>
+    <ul id="other-issues-list" role="list" class="mt-3 divide-y divide-gray-100 dark:divide-[#17181c]"></ul>
   </section>
 
   {# Summary card #}
-  <section class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+  <section class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
     <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-200 uppercase tracking-wide">Summary</h3>
     <dl class="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
       <div><dt class="text-gray-500">Query type</dt><dd class="mt-0.5 font-medium text-gray-900 dark:text-white">{{ query.query_type }}</dd></div>
@@ -126,17 +126,17 @@
   </section>
 
   {% if not is_anonymous %}
-  <section class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+  <section class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
     <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
       <p class="text-sm font-medium text-gray-700 dark:text-slate-200">Was this analysis helpful?</p>
       <div class="flex gap-2">
-        <button id="thumbs-up" onclick="submitQuickFeedback(true)" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded border border-gray-300 dark:border-[#30363d] text-sm hover:bg-gray-50 dark:hover:bg-[#21262d] transition">
+        <button id="thumbs-up" onclick="submitQuickFeedback(true)" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded border border-gray-300 dark:border-[#1f1f23] text-sm hover:bg-gray-50 dark:hover:bg-[#17181c] transition">
           <span>👍</span><span>Helpful</span>
         </button>
-        <button id="thumbs-down" onclick="submitQuickFeedback(false)" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded border border-gray-300 dark:border-[#30363d] text-sm hover:bg-gray-50 dark:hover:bg-[#21262d] transition">
+        <button id="thumbs-down" onclick="submitQuickFeedback(false)" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded border border-gray-300 dark:border-[#1f1f23] text-sm hover:bg-gray-50 dark:hover:bg-[#17181c] transition">
           <span>👎</span><span>Not helpful</span>
         </button>
-        <a href="{% url 'submit_feedback' analysis.id %}" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded border border-gray-300 dark:border-[#30363d] text-sm text-indigo-700 dark:text-indigo-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition">
+        <a href="{% url 'submit_feedback' analysis.id %}" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded border border-gray-300 dark:border-[#1f1f23] text-sm text-indigo-700 dark:text-indigo-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition">
           <span>💬</span><span>Detailed feedback</span>
         </a>
       </div>
@@ -145,8 +145,8 @@
   </section>
   {% endif %}
 
-  <section class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d]">
-    <div class="flex items-center justify-between px-5 py-3 border-b border-gray-100 dark:border-[#21262d]">
+  <section class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23]">
+    <div class="flex items-center justify-between px-5 py-3 border-b border-gray-100 dark:border-[#17181c]">
       <h3 class="text-sm font-semibold text-slate-700 dark:text-slate-200 uppercase tracking-wide">Analyzed query</h3>
       <button onclick="copyToClipboard('analyzed-query', 'Query copied!')" class="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">📋 Copy</button>
     </div>
@@ -154,7 +154,7 @@
   </section>
 
   {% if analysis.issues_found %}
-  <section class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+  <section class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
     <h3 class="text-base font-semibold text-gray-900 dark:text-white flex items-center gap-2"><span>🔍</span><span>All issues</span></h3>
     <ul class="mt-4 space-y-3">
       {% for issue in analysis.issues_found %}
@@ -181,14 +181,14 @@
   {% endif %}
 
   {% if analysis.recommendations %}
-  <section class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+  <section class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
     <div class="flex items-center justify-between">
       <h3 class="text-base font-semibold text-gray-900 dark:text-white flex items-center gap-2"><span>💡</span><span>Recommendations</span></h3>
       <button onclick="copyAllRecommendations()" class="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">📋 Copy all</button>
     </div>
     <ul id="recommendations-list" class="mt-4 space-y-3">
       {% for rec in analysis.recommendations %}
-      <li id="fix-{{ forloop.counter0 }}" tabindex="-1" class="qg-anchor-target recommendation-item rounded-md border border-gray-200 dark:border-[#30363d] p-4">
+      <li id="fix-{{ forloop.counter0 }}" tabindex="-1" class="qg-anchor-target recommendation-item rounded-md border border-gray-200 dark:border-[#1f1f23] p-4">
         <div class="flex items-center justify-between gap-2">
           <span class="recommendation-type text-sm font-semibold text-gray-900 dark:text-white">{{ rec.type|title }}</span>
           <span class="priority-badge text-xs font-medium px-2 py-0.5 rounded
@@ -220,7 +220,7 @@
 
   {% with idx_block=analysis.index_recommendations %}
   {% if idx_block.recommendations %}
-  <details id="index-recommendations" class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5" {% if g == 'c' or g == 'd' or g == 'f' %}open{% endif %}>
+  <details id="index-recommendations" class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5" {% if g == 'c' or g == 'd' or g == 'f' %}open{% endif %}>
     <summary class="cursor-pointer flex items-center justify-between flex-wrap gap-2 list-none">
       <h3 class="text-base font-semibold text-gray-900 dark:text-white flex items-center gap-2">
         <span>🗂️</span><span>Index recommendations</span>
@@ -242,7 +242,7 @@
 
     <ul class="mt-4 space-y-3">
       {% for rec in idx_block.recommendations %}
-      <li class="rounded-md border border-gray-200 dark:border-[#30363d] p-4">
+      <li class="rounded-md border border-gray-200 dark:border-[#1f1f23] p-4">
         <div class="flex items-center justify-between gap-2 flex-wrap">
           <span class="text-sm font-semibold text-gray-900 dark:text-white">
             {{ rec.table }}({{ rec.columns|join:", " }})
@@ -284,17 +284,17 @@
   {% endwith %}
 
   {% if optimization_result and optimization_result.optimizations_applied %}
-  <section class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+  <section class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
     <div class="flex items-center justify-between">
       <h3 class="text-base font-semibold text-gray-900 dark:text-white flex items-center gap-2"><span>🚀</span><span>Optimization suggestions</span></h3>
       <button onclick="copyToClipboard('optimized-query', 'Optimized query copied!')" class="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">📋 Copy optimized</button>
     </div>
     <div class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-      <div class="rounded bg-gray-50 dark:bg-[#21262d] p-3 flex items-center gap-2"><span>🔧</span><span class="text-gray-500">Optimizations applied:</span><span class="ml-auto font-semibold text-gray-900 dark:text-white">{{ optimization_result.optimizations_applied|length }}</span></div>
+      <div class="rounded bg-gray-50 dark:bg-[#17181c] p-3 flex items-center gap-2"><span>🔧</span><span class="text-gray-500">Optimizations applied:</span><span class="ml-auto font-semibold text-gray-900 dark:text-white">{{ optimization_result.optimizations_applied|length }}</span></div>
       <div class="rounded bg-emerald-50 p-3 flex items-center gap-2"><span>📈</span><span class="text-gray-500">Estimated improvement:</span><span class="ml-auto font-semibold text-emerald-700">{{ optimization_result.improvement_estimate }}%</span></div>
     </div>
 
-    <div class="mt-4 border-b border-gray-200 dark:border-[#30363d] flex gap-1">
+    <div class="mt-4 border-b border-gray-200 dark:border-[#1f1f23] flex gap-1">
       <button id="optimized-tab" class="opt-tab-btn px-3 py-1.5 text-sm font-medium text-indigo-700 border-b-2 border-indigo-600 -mb-px" onclick="showOptimizationTab('optimized')">Optimized</button>
       <button id="comparison-tab" class="opt-tab-btn px-3 py-1.5 text-sm font-medium text-gray-500 hover:text-gray-700 border-b-2 border-transparent -mb-px" onclick="showOptimizationTab('comparison')">Side-by-side</button>
       <button id="explanations-tab" class="opt-tab-btn px-3 py-1.5 text-sm font-medium text-gray-500 hover:text-gray-700 border-b-2 border-transparent -mb-px" onclick="showOptimizationTab('explanations')">Explanations</button>
@@ -348,14 +348,14 @@
   {% endif %}
 
   {% if analysis.performance_notes %}
-  <section class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+  <section class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
     <h3 class="text-base font-semibold text-gray-900 dark:text-white flex items-center gap-2"><span>📊</span><span>Performance notes</span></h3>
     <p class="mt-2 text-sm text-gray-700 dark:text-slate-300 whitespace-pre-wrap">{{ analysis.performance_notes }}</p>
   </section>
   {% endif %}
 
   {% if user_history.database_type or user_history.database_version or user_history.use_case_notes %}
-  <section class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+  <section class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
     <h3 class="text-base font-semibold text-gray-900 dark:text-white flex items-center gap-2"><span>📝</span><span>Query context</span></h3>
     <dl class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
       {% if user_history.database_type %}<div><dt class="text-gray-500">Database</dt><dd class="mt-0.5 font-medium text-gray-900 dark:text-white">{{ user_history.database_type|title }}</dd></div>{% endif %}
@@ -372,11 +372,11 @@
 
   <div class="flex flex-wrap items-center gap-3 pt-2">
     <a href="{% url 'grade_query' %}"
-       class="inline-flex items-center justify-center gap-2 px-5 py-3 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-md min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-indigo-500">
+       class="inline-flex items-center justify-center gap-2 px-5 py-3 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-md min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-indigo-500">
       Grade another query
     </a>
     {% if not is_anonymous %}
-    <a href="{% url 'query_history' %}" class="inline-flex items-center gap-1 px-3 py-2 border border-gray-300 dark:border-[#30363d] text-gray-700 dark:text-gray-200 text-sm rounded-md hover:bg-gray-50 dark:hover:bg-[#21262d]">View history</a>
+    <a href="{% url 'query_history' %}" class="inline-flex items-center gap-1 px-3 py-2 border border-gray-300 dark:border-[#1f1f23] text-gray-700 dark:text-gray-200 text-sm rounded-md hover:bg-gray-50 dark:hover:bg-[#17181c]">View history</a>
     <a href="{% url 'submit_feedback' analysis.id %}" class="text-sm text-slate-600 dark:text-slate-300 hover:underline">💬 Detailed feedback</a>
     {% endif %}
     <button onclick="copyFullReport()" class="text-sm text-slate-600 dark:text-slate-300 hover:underline">📋 Copy report</button>
@@ -848,7 +848,7 @@
         const li = document.createElement('li');
         const a = document.createElement('a');
         a.href = '#issue-' + i;
-        a.className = 'flex items-start gap-2 px-2 py-1.5 rounded text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-[#21262d] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500';
+        a.className = 'flex items-start gap-2 px-2 py-1.5 rounded text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-[#17181c] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500';
         const sev = iss.severity || 'low';
         const colorCls = severityColorClasses(sev);
         const glyph = document.createElement('span');

--- a/analyzer/templates/analyzer/index.html
+++ b/analyzer/templates/analyzer/index.html
@@ -128,22 +128,22 @@ if (document.getElementById('uploadForm')) {
   </header>
 
   {% if trial_exhausted %}
-  <section class="bg-white dark:bg-[#161b22] rounded-xl border border-indigo-200 dark:border-indigo-900 p-8 text-center space-y-4 shadow-sm">
+  <section class="bg-white dark:bg-[#111113] rounded-xl border border-indigo-200 dark:border-indigo-900 p-8 text-center space-y-4 shadow-sm">
     <div class="text-4xl">🚀</div>
     <h2 class="font-mono text-2xl font-semibold text-gray-900 dark:text-white">You've used all {{ trial_cap }} free trials</h2>
     <p class="text-gray-600 dark:text-gray-300 max-w-xl mx-auto">Create a free account to keep grading queries — plus unlock AI rewrite suggestions, personalized feedback, query history, and saved reports.</p>
     <div class="flex flex-col items-center gap-3 pt-2">
       <a href="{% url 'register' %}"
-         class="inline-flex items-center justify-center px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-emerald-500 min-h-[44px]">
+         class="inline-flex items-center justify-center px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-emerald-500 min-h-[44px]">
         Create account
       </a>
-      <a href="{% url 'login' %}" class="text-sm text-slate-600 dark:text-slate-300 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-indigo-500 rounded">Already have an account? Log in</a>
+      <a href="{% url 'login' %}" class="text-sm text-slate-600 dark:text-slate-300 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-indigo-500 rounded">Already have an account? Log in</a>
     </div>
   </section>
   {% else %}
 
   {# Input card #}
-  <section class="bg-white dark:bg-[#161b22] rounded-xl border border-gray-200 dark:border-[#30363d] shadow-sm p-6 sm:p-8">
+  <section class="bg-white dark:bg-[#111113] rounded-xl border border-gray-200 dark:border-[#1f1f23] shadow-sm p-6 sm:p-8">
     <form id="inlineGradeForm" class="space-y-4" novalidate>
       {% csrf_token %}
       {# DB engine chips (radio group, roving tabindex) — replaces the old <details> picker #}
@@ -155,7 +155,7 @@ if (document.getElementById('uploadForm')) {
                 aria-checked="{% if forloop.first %}true{% else %}false{% endif %}"
                 tabindex="{% if forloop.first %}0{% else %}-1{% endif %}"
                 data-db-value="{{ value }}"
-                class="db-chip flex-shrink-0 snap-start min-h-[44px] px-4 py-2 rounded-full text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-indigo-500
+                class="db-chip flex-shrink-0 snap-start min-h-[44px] px-4 py-2 rounded-full text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-indigo-500
                        {% if forloop.first %}bg-slate-900 text-white dark:bg-white dark:text-slate-900{% else %}bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-700{% endif %}">
           {{ label|default:"Auto-detect" }}
         </button>
@@ -166,11 +166,11 @@ if (document.getElementById('uploadForm')) {
 
       <div>
         <label for="id_sql_query" class="sr-only">SQL query</label>
-        <div id="sqlEditorWrap" class="rounded-lg border border-gray-300 dark:border-[#30363d] focus-within:ring-2 focus-within:ring-indigo-500 focus-within:border-indigo-500">
+        <div id="sqlEditorWrap" class="rounded-lg border border-gray-300 dark:border-[#1f1f23] focus-within:ring-2 focus-within:ring-indigo-500 focus-within:border-indigo-500">
           <textarea id="id_sql_query" name="sql_query" rows="8"
                     aria-describedby="sqlError"
                     aria-invalid="false"
-                    class="w-full px-4 py-3 rounded-lg text-base sm:text-sm font-mono bg-gray-50 dark:bg-[#0d1117] dark:text-[#e6edf3] focus:outline-none border-0"
+                    class="w-full px-4 py-3 rounded-lg text-base sm:text-sm font-mono bg-gray-50 dark:bg-[#0a0a0a] dark:text-[#e7e5e0] focus:outline-none border-0"
                     placeholder="SELECT u.name, COUNT(o.id)&#10;FROM users u&#10;LEFT JOIN orders o ON o.user_id = u.id&#10;WHERE u.created_at >= '2024-01-01'&#10;GROUP BY u.name&#10;ORDER BY 2 DESC;"></textarea>
         </div>
         <p id="sqlError" role="alert" class="mt-2 text-sm text-red-600 dark:text-red-400 hidden"></p>
@@ -180,7 +180,7 @@ if (document.getElementById('uploadForm')) {
       <div id="dbVersionWrap" class="hidden">
         <label for="id_database_version" class="block text-xs font-medium text-gray-700 dark:text-gray-300">Version (optional)</label>
         <input id="id_database_version" name="database_version" type="text" placeholder="e.g. 8.0, 15"
-               class="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-[#30363d] rounded-md text-sm bg-white dark:bg-[#0d1117] dark:text-[#e6edf3]">
+               class="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-[#1f1f23] rounded-md text-sm bg-white dark:bg-[#0a0a0a] dark:text-[#e7e5e0]">
       </div>
 
       <div class="flex items-center justify-between">
@@ -189,14 +189,14 @@ if (document.getElementById('uploadForm')) {
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
           Grade my query
         </button>
-        <p class="text-xs text-gray-500">Press <kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#30363d] text-[10px] font-mono">⌘ ↵</kbd> to submit</p>
+        <p class="text-xs text-gray-500">Press <kbd class="px-1.5 py-0.5 rounded border border-gray-300 dark:border-[#1f1f23] text-[10px] font-mono">⌘ ↵</kbd> to submit</p>
       </div>
     </form>
   </section>
 
   {# Loading panel (honest copy — no fake multi-stage progress) #}
   <section id="loadingPanel" role="status" aria-live="polite" aria-busy="true"
-           class="hidden bg-white dark:bg-[#161b22] rounded-xl border border-gray-200 dark:border-[#30363d] shadow-sm p-6">
+           class="hidden bg-white dark:bg-[#111113] rounded-xl border border-gray-200 dark:border-[#1f1f23] shadow-sm p-6">
     <p id="loadingLabel" class="text-sm font-medium text-gray-700 dark:text-gray-200">Analyzing your query…</p>
     <div class="mt-3 h-1 bg-indigo-100 dark:bg-indigo-900/40 overflow-hidden rounded-full">
       <div class="qg-indeterminate-bar h-full w-1/3 bg-indigo-600 rounded-full"></div>
@@ -212,19 +212,19 @@ if (document.getElementById('uploadForm')) {
     <p class="text-center text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">Every grade is the product of deterministic rules <em>and</em> a model that keeps learning from real engineers like you.</p>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4 pt-2">
-      <div class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+      <div class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
         <div class="text-2xl">📐</div>
         <h3 class="mt-2 font-semibold text-gray-900 dark:text-white">Rule-based grading</h3>
         <p class="mt-1.5 text-sm text-gray-600 dark:text-gray-300">Nine specialized analyzers (SELECT, JOIN, WHERE, indexing, subqueries, ORDER BY, GROUP BY, plus MySQL- and PostgreSQL-specific patterns) detect <strong>18+ issue types</strong> and emit <strong>27+ recommendation types</strong>. Output is a letter grade A–F with a 0–100 score.</p>
       </div>
 
-      <div class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+      <div class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
         <div class="text-2xl">🤖</div>
         <h3 class="mt-2 font-semibold text-gray-900 dark:text-white">ML-powered refinement</h3>
         <p class="mt-1.5 text-sm text-gray-600 dark:text-gray-300">A hybrid model trained on curated query corpora and user feedback weights the rule-based score. When the model is confident, its prediction nudges the final grade so it reflects how queries actually perform — not just how strict our rules are.</p>
       </div>
 
-      <div class="bg-white dark:bg-[#161b22] rounded-lg border border-gray-200 dark:border-[#30363d] p-5">
+      <div class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
         <div class="text-2xl">🧠</div>
         <h3 class="mt-2 font-semibold text-gray-900 dark:text-white">You make it smarter</h3>
         <p class="mt-1.5 text-sm text-gray-600 dark:text-gray-300">Every thumbs-up / thumbs-down on an analysis becomes training data. Periodic retraining means today's grades reflect what real engineers found helpful yesterday.</p>
@@ -392,7 +392,7 @@ if (document.getElementById('uploadForm')) {
       : '';
 
     resultPanel.innerHTML = `
-      <section class="bg-white dark:bg-[#161b22] rounded-xl border border-gray-200 dark:border-[#30363d] p-6 flex flex-col md:flex-row gap-6 shadow-sm">
+      <section class="bg-white dark:bg-[#111113] rounded-xl border border-gray-200 dark:border-[#1f1f23] p-6 flex flex-col md:flex-row gap-6 shadow-sm">
         <div class="flex-shrink-0 flex flex-col items-center justify-center text-center md:w-40 p-4 rounded-lg ring-1 ${theme.surface}">
           <div class="text-6xl font-bold leading-none ${theme.text}">${escapeHtml(grade)}</div>
           <div class="mt-2 font-mono tabular-nums text-2xl font-semibold text-gray-900 dark:text-white">${escapeHtml(score)}<span class="text-base text-gray-500">/100</span></div>
@@ -412,11 +412,11 @@ if (document.getElementById('uploadForm')) {
       </section>
 
       <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div class="bg-white dark:bg-[#161b22] rounded-xl border border-gray-200 dark:border-[#30363d] p-5">
+        <div class="bg-white dark:bg-[#111113] rounded-xl border border-gray-200 dark:border-[#1f1f23] p-5">
           <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Issues detected</h3>
           <ul class="mt-3 space-y-2">${issuesHtml}</ul>
         </div>
-        <div class="bg-white dark:bg-[#161b22] rounded-xl border border-gray-200 dark:border-[#30363d] p-5">
+        <div class="bg-white dark:bg-[#111113] rounded-xl border border-gray-200 dark:border-[#1f1f23] p-5">
           <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Recommendations</h3>
           <ul class="mt-3 space-y-2">${recsHtml}</ul>
         </div>
@@ -428,11 +428,11 @@ if (document.getElementById('uploadForm')) {
 
       <div class="flex flex-wrap items-center gap-4 pt-2">
         <a href="${escapeHtml(d.results_url)}"
-           class="inline-flex items-center justify-center px-5 py-3 rounded-md bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-indigo-500">
+           class="inline-flex items-center justify-center px-5 py-3 rounded-md bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-indigo-500">
           Open full report &rarr;
         </a>
         <button type="button" id="gradeAgainBtn"
-                class="text-sm text-slate-600 dark:text-slate-300 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-indigo-500 rounded">
+                class="text-sm text-slate-600 dark:text-slate-300 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-indigo-500 rounded">
           Grade another query
         </button>
       </div>
@@ -462,13 +462,13 @@ if (document.getElementById('uploadForm')) {
   let formLocked = false;
   function renderExhausted(d) {
     resultPanel.innerHTML = `
-      <section class="bg-white dark:bg-[#161b22] rounded-xl border border-indigo-200 dark:border-indigo-900 p-8 text-center space-y-4 shadow-sm">
+      <section class="bg-white dark:bg-[#111113] rounded-xl border border-indigo-200 dark:border-indigo-900 p-8 text-center space-y-4 shadow-sm">
         <div class="text-4xl">🚀</div>
         <h2 class="font-mono text-2xl font-semibold text-gray-900 dark:text-white">You've used all ${d.cap} free trials</h2>
         <p class="text-gray-600 dark:text-gray-300 max-w-xl mx-auto">Create a free account to keep grading queries — plus unlock AI rewrite suggestions, personalized feedback, query history, and saved reports.</p>
         <div class="flex flex-col items-center gap-3 pt-2">
           <a href="${escapeHtml(d.register_url)}"
-             class="inline-flex items-center justify-center px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold rounded-md min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0d1117] focus-visible:ring-emerald-500">
+             class="inline-flex items-center justify-center px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold rounded-md min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-emerald-500">
             Create account
           </a>
           <a href="${escapeHtml(d.login_url)}" class="text-sm text-slate-600 dark:text-slate-300 hover:underline">Already have an account? Log in</a>


### PR DESCRIPTION
## Summary

Replace the GitHub-Primer-style dark palette with the surface tokens planted (but never wired) in Slice C. Single mechanical hex swap across `dark-mode.css` and the four templates carrying inline `dark:bg-[#…]` arbitrary values.

| Role | Before | After |
|---|---|---|
| Page background | \`#0d1117\` | \`#0a0a0a\` |
| Card / panel surface | \`#161b22\` | \`#111113\` |
| Border | \`#30363d\` | \`#1f1f23\` |
| Ink (primary text) | \`#e6edf3\` | \`#e7e5e0\` |
| \`bg-slate-100/800\` dark override | \`#21262d\` | \`#17181c\` |
| Hover lift | \`#2d333b\` | \`#25272d\` |

## Why

Side-by-side screenshots showed Dark Reader's auto-rework reading noticeably warmer, blacker, and more "dev tool" than the native dark theme. The UX-pass critique (`02-critique.md` #8) already flagged dark mode as "light-mode-flipped" and proposed a `#0a0a0a` base; Slice C even planted the surface tokens but only used them for one demo surface. This wires them everywhere.

## Theme toggle behavior

Unchanged. `base.html` already defaults to `prefers-color-scheme` and persists user overrides to `localStorage` via the `.theme-toggle` button — that established in the original dark-mode shipping work. No new toggle, no migration.

## Test plan

- [ ] `python manage.py check` → 0 issues (passes)
- [ ] Smoke-rendered `/`, `/login/`, `/register/` → 200
- [ ] Toggle dark mode on every in-scope page (`/`, `/grade/`, `/grade/results/<id>/`, `/history/`, `/account/`); verify no contrast regression
- [ ] System toggle: switch macOS appearance — site flips when localStorage override is absent
- [ ] CodeMirror editors render against new card surface (not the old `#161b22`)
- [ ] Grade pills, severity dots, line-highlight `.qg-line-issue` background still distinct against new bg