### PR TITLE
fix(ui): warm-cream heading ink + manifest static storage for cache busts

### DIFF
--- a/analyzer/static/analyzer/css/dark-mode.css
+++ b/analyzer/static/analyzer/css/dark-mode.css
@@ -253,6 +253,13 @@ html.dark .text-slate-700      { color: #cdd9e5; }
 html.dark .hover\:bg-slate-200:hover { background-color: #25272d; }
 html.dark .hover\:bg-slate-700:hover { background-color: #25272d; }
 
+/* ─── Warm-cream ink override for headings using dark:text-white ─── */
+/* Pure white headings on a near-OLED background read clinical and cool. */
+/* Soften every dark:text-white usage to the warm-cream ink without */
+/* per-template churn. Same specificity as Tailwind's .dark .dark\:text-white; */
+/* dark-mode.css loads after the Tailwind CDN, so source order wins here. */
+html.dark .dark\:text-white { color: #e7e5e0; }
+
 /* ─── Indeterminate loading bar (honest loading copy in anon path) ─── */
 @keyframes qg-indeterminate-slide {
   0%   { transform: translateX(-100%); }

--- a/querygrade/settings.py
+++ b/querygrade/settings.py
@@ -452,8 +452,19 @@ FILE_UPLOAD_PERMISSIONS = 0o644
 USE_ETAGS = True
 USE_TZ = True
 
-# Static files optimization
-STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
+# Static files optimization. ManifestStaticFilesStorage hashes filenames
+# (e.g. dark-mode.abc123.css) so deploys invalidate browser caches without
+# every user needing a hard-refresh — previous CompressedStaticFilesStorage
+# kept stable URLs and left clients on stale CSS for hours after a deploy.
+# Django 4.2+ uses STORAGES dict; STATICFILES_STORAGE is deprecated.
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 
 # Template performance
 TEMPLATES[0]["OPTIONS"]["context_processors"].extend(


### PR DESCRIPTION
## Summary

Two related fixes following PR #58's near-OLED palette swap, which appeared not to deploy because of stale browser caches.

### 1. Heading text was still pure white

49 templates use Tailwind \`dark:text-white\` which generates a \`#ffffff\` rule and ignored the warm \`#e7e5e0\` ink token from PR #58. Rather than touch 49 templates, add a single override in \`dark-mode.css\` that retargets \`.dark\:text-white\` to \`#e7e5e0\`. Same specificity as Tailwind's own rule; \`dark-mode.css\` loads after the Tailwind CDN, so source order wins.

### 2. Browser caches were holding the old CSS

Whitenoise was using \`CompressedStaticFilesStorage\` — stable URLs across deploys, no cache invalidation. Switched to \`CompressedManifestStaticFilesStorage\` so files now ship with content-hashed names (e.g. \`dark-mode.bd121d.css\`). Each deploy produces fresh URLs, and clients pick up the new CSS on the next page load instead of needing a hard-refresh.

Django 5.2 uses the new \`STORAGES\` dict — the older \`STATICFILES_STORAGE\` setting was deprecated in 4.2 and silently ignored under the new resolution path. This was why the initial attempt to set \`STATICFILES_STORAGE\` to manifest storage left \`ConfiguredStorage\` resolving to the FileSystem default.

## Verification

- \`collectstatic --clear\` → \`169 static files copied, 799 post-processed\` (no missing-reference errors)
- \`python manage.py check\` → 0 issues
- Smoke-rendered \`/\`, \`/login/\`, \`/register/\`, \`/grade/\` → 200
- Confirmed \`staticfiles/analyzer/css/dark-mode.bd121dedd6a4.css\` (+ .br + .gz) generated

## Test plan

- [ ] Railway redeploy completes; \`curl https://querygrade.com/ | grep dark-mode\` shows a hashed CSS URL
- [ ] Visit site in a fresh browser session — hero heading renders warm cream, not pure white
- [ ] Existing browsers pick up the new CSS without manual hard-refresh on next page load