### PR TITLE
fix(ui): soften saturated accents in dark mode

### DIFF
--- a/analyzer/static/analyzer/css/dark-mode.css
+++ b/analyzer/static/analyzer/css/dark-mode.css
@@ -66,6 +66,22 @@ html.dark .bg-gray-50       { background-color: #0a0a0a; }
 html.dark .bg-gray-100      { background-color: #17181c; }
 html.dark .bg-gray-200      { background-color: #25272d; }
 
+/* ─── Primary indigo CTA mute (PR #60)
+   Light-mode indigo-600 (#4f46e5) reads as a UI alert against #0a0a0a.
+   At-rest drops to indigo-700; hover BRIGHTENS to indigo-500 so the
+   affordance direction inverts vs light mode (where hover darkens). */
+html.dark .bg-indigo-600           { background-color: #4338ca; }
+html.dark .hover\:bg-indigo-700:hover { background-color: #6366f1; }
+
+/* ─── Selected DB chip (and anywhere else inverting to white) ───
+   Pure white pills on near-OLED black are the harshest contrast on the
+   page — they read like a UI block, not a "this is selected" affordance.
+   Pull the dark:bg-white inversion to the warm-cream ink token instead. */
+html.dark [role="radio"][aria-checked="true"] {
+  background-color: #e7e5e0;
+  color: #0a0a0a;
+}
+
 /* ─── Text scale ─── */
 html.dark .text-gray-950    { color: #e7e5e0; }
 html.dark .text-gray-900    { color: #e7e5e0; }
@@ -137,7 +153,7 @@ html.dark .border-amber-200 { border-color: rgba(217, 119, 6, 0.3); }
    Per-color bg opacity bumps + brighter -300 text gives each grade a distinct read
    in dark mode while preserving WCAG AA contrast. Compound selectors (.bg-X.text-Y)
    beat the generic single-class fallbacks below.                                  */
-html.dark .bg-emerald-100.text-emerald-700 { background-color: rgba(16, 185, 129, 0.22); color: #6ee7b7; }
+html.dark .bg-emerald-100.text-emerald-700 { background-color: rgba(16, 185, 129, 0.22); color: #34d399; }
 html.dark .bg-lime-100.text-lime-700       { background-color: rgba(132, 204, 22, 0.22); color: #bef264; }
 html.dark .bg-amber-100.text-amber-700     { background-color: rgba(217, 119, 6, 0.25); color: #fcd34d; }
 html.dark .bg-orange-100.text-orange-700   { background-color: rgba(234, 88, 12, 0.28); color: #fdba74; }


### PR DESCRIPTION
## Why

The near-OLED palette swap (#58) lowered surface luminance to \`#0a0a0a\` but left every accent at light-mode saturation. Result: the Register button, selected DB chip, and credits pill punch harder than the actual headings — they read as UI alerts, not brand accents. Visible in the user-reported screenshots from the post-#58 review.

## Three targeted overrides in dark-mode.css

| Surface | Before | After | Rationale |
|---|---|---|---|
| Primary indigo CTA at-rest | \`#4f46e5\` (indigo-600) | \`#4338ca\` (indigo-700) | Mute the resting state so it sits at heading luminance, not above. |
| Primary indigo CTA hover | \`#4338ca\` (indigo-700) | \`#6366f1\` (indigo-500) | Hover brightens, inverting the light-mode affordance direction (where hover darkens) — preserves "this is intent" feedback. |
| Selected DB chip | \`bg-white text-slate-900\` (pure white) | \`bg-[#e7e5e0] text-[#0a0a0a]\` (warm cream) | Pure white on near-OLED was the harshest contrast on the page; warm cream still reads as "selected" without screaming. Scoped to \`[role="radio"][aria-checked="true"]\` so other \`dark:bg-white\` usages are unaffected. |
| Credits / grade-A emerald pill text | \`#6ee7b7\` (emerald-300) | \`#34d399\` (emerald-400) | ~30% less luminous on the same rgba bg; still readable. |

No template churn — single CSS file edit.

## Out of scope (deliberately deferred)

- Wordmark \`#a5b4fc\` softening — brand-identity call.
- Q-ring logo stroke desaturation — brand-identity call.
- Navbar shadow seam (separate report: \`html.dark .shadow-sm\` is forcing a heavy custom shadow despite \`dark:shadow-none\`). Tracked for a follow-up.

## Verification

- \`collectstatic --clear\` → 169 files, 799 post-processed, no missing refs.
- \`python manage.py check\` → 0 issues.
- Cascade check: \`html.dark .bg-indigo-600\` (0,2,1) beats Tailwind's \`.bg-indigo-600\` (0,1,0); \`html.dark [role="radio"][aria-checked="true"]\` (0,3,1) beats \`html.dark .dark\\:bg-white\` (0,2,1).

## Test plan

- [ ] Railway redeploy completes; new content-hashed \`dark-mode.<hash>.css\` URL is served
- [ ] \`/\` and \`/grade/\` Register / Grade-my-query buttons no longer dominate the navbar / page
- [ ] DB chip group: clicking through MySQL/PG/SQLite shows warm cream selected state (no white blowout)
- [ ] Hover the primary CTA: should visibly brighten in dark mode
- [ ] Credits pill emerald reads softer; grade-A pills on \`/account/\` and history match the new tone