### PR TITLE
fix(ui): restrain dark-mode pills (chip wash + lower pill bg opacity)

### DIFF
--- a/analyzer/static/analyzer/css/dark-mode.css
+++ b/analyzer/static/analyzer/css/dark-mode.css
@@ -73,13 +73,15 @@ html.dark .bg-gray-200      { background-color: #25272d; }
 html.dark .bg-indigo-600           { background-color: #4338ca; }
 html.dark .hover\:bg-indigo-700:hover { background-color: #6366f1; }
 
-/* ─── Selected DB chip (and anywhere else inverting to white) ───
-   Pure white pills on near-OLED black are the harshest contrast on the
-   page — they read like a UI block, not a "this is selected" affordance.
-   Pull the dark:bg-white inversion to the warm-cream ink token instead. */
+/* ─── Selected DB chip ───
+   Even warm-cream (#e7e5e0) is essentially a near-white pill on near-black —
+   95% luminance against ~4%. Wrong for dark mode regardless of the tint.
+   Switch to a subtle indigo wash + soft indigo text + inset indigo border:
+   uses brand color to signal "selected" instead of brute-force luminance. */
 html.dark [role="radio"][aria-checked="true"] {
-  background-color: #e7e5e0;
-  color: #0a0a0a;
+  background-color: rgba(99, 102, 241, 0.18);
+  color: #c7d2fe;
+  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.4);
 }
 
 /* ─── Text scale ─── */
@@ -153,11 +155,15 @@ html.dark .border-amber-200 { border-color: rgba(217, 119, 6, 0.3); }
    Per-color bg opacity bumps + brighter -300 text gives each grade a distinct read
    in dark mode while preserving WCAG AA contrast. Compound selectors (.bg-X.text-Y)
    beat the generic single-class fallbacks below.                                  */
-html.dark .bg-emerald-100.text-emerald-700 { background-color: rgba(16, 185, 129, 0.22); color: #34d399; }
-html.dark .bg-lime-100.text-lime-700       { background-color: rgba(132, 204, 22, 0.22); color: #bef264; }
-html.dark .bg-amber-100.text-amber-700     { background-color: rgba(217, 119, 6, 0.25); color: #fcd34d; }
-html.dark .bg-orange-100.text-orange-700   { background-color: rgba(234, 88, 12, 0.28); color: #fdba74; }
-html.dark .bg-red-100.text-red-700         { background-color: rgba(239, 68, 68, 0.28); color: #fca5a5; }
+/* PR #61: bg opacity ~halved (22-28% → 10-16%) so pills read as ambient
+   indicators rather than saturated notification chips. Text colors preserved
+   for legibility — the chip becomes a quiet wash with colored text floating
+   on near-OLED, not a glowing brand block. */
+html.dark .bg-emerald-100.text-emerald-700 { background-color: rgba(16, 185, 129, 0.10); color: #34d399; }
+html.dark .bg-lime-100.text-lime-700       { background-color: rgba(132, 204, 22, 0.10); color: #a3e635; }
+html.dark .bg-amber-100.text-amber-700     { background-color: rgba(217, 119, 6, 0.12); color: #fcd34d; }
+html.dark .bg-orange-100.text-orange-700   { background-color: rgba(234, 88, 12, 0.14); color: #fdba74; }
+html.dark .bg-red-100.text-red-700         { background-color: rgba(239, 68, 68, 0.14); color: #fca5a5; }
 
 /* Single-class fallbacks (used outside the pill compound — e.g. icon backgrounds) */
 html.dark .bg-emerald-100   { background-color: rgba(16, 185, 129, 0.18); }


### PR DESCRIPTION
## Why

User feedback on PR #60: the "warm cream" selected chip was still a near-white block (95% luminance vs ~4% page), and the emerald credits pill was still glowing at 22% saturation. Both read as bright UI alerts in an otherwise muted dark palette — wrong for the aesthetic regardless of the hex codes.

## Two scoped changes

### 1. Selected DB chip → indigo wash

```css
html.dark [role="radio"][aria-checked="true"] {
  background-color: rgba(99, 102, 241, 0.18);
  color: #c7d2fe;
  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.4);
}
```

Affordance now comes from brand indigo wash + inset border, not luminance contrast. Still visually distinct from the `#17181c` unselected chips.

### 2. Grade/status pill backgrounds: halve opacity

| Color | Before | After |
|---|---|---|
| emerald | `rgba(16,185,129,0.22)` | `rgba(16,185,129,0.10)` |
| lime | `rgba(132,204,22,0.22)` | `rgba(132,204,22,0.10)` |
| amber | `rgba(217,119,6,0.25)` | `rgba(217,119,6,0.12)` |
| orange | `rgba(234,88,12,0.28)` | `rgba(234,88,12,0.14)` |
| red | `rgba(239,68,68,0.28)` | `rgba(239,68,68,0.14)` |

Text colors preserved (lime bumped to `#a3e635` to compensate for the dimmer bg). Pills now read as ambient indicators with colored text floating on near-OLED, not saturated chips.

## Verification

- collectstatic → 169 / 799 ✅
- Same compound selectors as the existing grade-pill rules; specificity (0,2,1) beats single-class fallbacks.
- Selected chip has higher-specificity selector (0,3,1) than `html.dark .dark\:bg-white` (0,2,1) so the override still wins.

## Test plan

- [ ] DB chip group: the active chip is a subtle indigo wash, not a bright block
- [ ] Credits pill (`50/50 credits` / `50 of 50 free grades remaining…`) reads as ambient info, not a glowing alert
- [ ] Grade A pill on `/account/` and `/history/` is restrained but distinct from grade B/C/D/F
