### PR TITLE
fix(ui): load CodeMirror placeholder addon on anon landing

### DIFF
--- a/analyzer/templates/analyzer/index.html
+++ b/analyzer/templates/analyzer/index.html
@@ -258,6 +258,7 @@ if (document.getElementById('uploadForm')) {
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/hint/sql-hint.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/edit/matchbrackets.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/edit/closebrackets.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/display/placeholder.min.js"></script>
 
 {# Inline JS — keeps things self-contained; no new static file. #}
 <script>


### PR DESCRIPTION
Followup to #63 — the editor rendered with no placeholder text because CodeMirror 5 silently ignores the `placeholder:` option unless `addon/display/placeholder.min.js` is loaded. One-line script include.