### PR TITLE
chore(deps): drop unused django-security pin blocking CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ redis>=4.0.0
 django-redis>=5.0.0
 
 # Security & Configuration
-django-security==1.1.2
 django-csp==4.0
 django-ratelimit==4.1.0
 python-decouple>=3.8


### PR DESCRIPTION
## Summary
- `django-security==1.1.2` doesn't exist on PyPI (latest published is 0.12.0), so `pip install -r requirements.txt` fails before tests run
- Package is **not imported anywhere** in the codebase (verified via grep for `django_security` and `from django_security` — zero hits)
- Removing the pin restores genuine CI signal so future PRs get real green/red status instead of relying on \`--admin\` merge overrides

## Test plan
- [ ] CI "Test Suite" check reaches the test step (no "No matching distribution found" failure on install)
- [ ] Existing test pass-rate unchanged after merge