### PR TITLE
fix(security): port json_script pattern to enhanced_grade_results.html

### DIFF
--- a/analyzer/templates/analyzer/enhanced_grade_results.html
+++ b/analyzer/templates/analyzer/enhanced_grade_results.html
@@ -481,6 +481,7 @@
   </div>
 </div>
 
+{{ analysis.issues_found|json_script:"issues-json" }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/sql/sql.min.js"></script>
 <script>
@@ -654,7 +655,7 @@
       if (window.QG && window.QG.registerEditor) window.QG.registerEditor(ed);
     });
 
-    const issues = {{ analysis.issues_found|safe }};
+    const issues = JSON.parse(document.getElementById('issues-json').textContent) || [];
     const counts = {critical: 0, high: 0, medium: 0, low: 0};
     issues.forEach(i => { if (counts.hasOwnProperty(i.severity)) counts[i.severity]++; });
     ['critical', 'high', 'medium', 'low'].forEach(k => {


### PR DESCRIPTION
## Summary
- \`enhanced_grade_results.html:657\` interpolated \`analysis.issues_found\` into a \`<script>\` block via \`|safe\` — pre-existing XSS risk flagged in CLAUDE.md
- Port the \`json_script\` pattern already proven in \`grade_results.html:401\`: \`{{ field|json_script:\"issues-json\" }}\` + \`JSON.parse(document.getElementById('issues-json').textContent)\`
- Django's \`json_script\` escapes \`<\`, \`>\`, \`&\` for the embed context and emits valid JSON

## Test plan
- [ ] \`/grade/results/<id>/\` (enhanced view) loads and severity counts (critical/high/medium/low) render correctly
- [ ] View-source on the response shows no raw \`{{ … }}\` interpolation inside \`<script>\`
- [ ] No regression in star-rating row, gtag event, or progress-bar animation that runs in the same script block