### PR TITLE
fix(ml): replace deprecated PassiveAggressiveRegressor; guard partial_fit

### DIFF
--- a/analyzer/ml/learning/incremental_engine.py
+++ b/analyzer/ml/learning/incremental_engine.py
@@ -27,7 +27,7 @@ try:
     import joblib
     from sklearn.base import BaseEstimator, RegressorMixin
     from sklearn.ensemble import RandomForestRegressor
-    from sklearn.linear_model import PassiveAggressiveRegressor, SGDRegressor
+    from sklearn.linear_model import SGDRegressor
     from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
     from sklearn.preprocessing import StandardScaler
 
@@ -451,10 +451,20 @@ class IncrementalLearningEngine:
                 n_estimators=20, max_depth=8, memory_limit=5000
             )
 
-            # Backup models for comparison
+            # Backup models for comparison.
+            # PassiveAggressiveRegressor was deprecated in sklearn 1.8 and removed
+            # in 1.10; the sklearn-recommended replacement is SGDRegressor with
+            # the PA-1 configuration, which also accepts sample_weight in
+            # partial_fit (PA did not).
             self.backup_models = [
                 SGDRegressor(learning_rate="adaptive", eta0=0.01, random_state=42),
-                PassiveAggressiveRegressor(C=1.0, random_state=42),
+                SGDRegressor(
+                    loss="epsilon_insensitive",
+                    penalty=None,
+                    learning_rate="pa1",
+                    eta0=1.0,
+                    random_state=42,
+                ),
             ]
 
             logger.info("Incremental learning models initialized")

--- a/analyzer/ml/monitoring/realtime_feedback.py
+++ b/analyzer/ml/monitoring/realtime_feedback.py
@@ -177,8 +177,14 @@ class OnlineLearningEngine:
 
             # Check if model supports partial_fit
             if hasattr(self.current_model, "partial_fit"):
-                # Direct incremental update
-                self.current_model.partial_fit(X, y, sample_weight=weights)
+                # Direct incremental update. Older estimators
+                # (e.g. PassiveAggressiveRegressor) do not accept sample_weight in
+                # partial_fit, so retry without weights on TypeError rather than
+                # let the whole update fail.
+                try:
+                    self.current_model.partial_fit(X, y, sample_weight=weights)
+                except TypeError:
+                    self.current_model.partial_fit(X, y)
                 update_method = "partial_fit"
             else:
                 # Simulate incremental learning with weighted update


### PR DESCRIPTION
## Summary
- sklearn 1.8 deprecates \`PassiveAggressiveRegressor\` (removal in 1.10) and dropped \`sample_weight\` from its \`partial_fit()\`, so the incremental-learning \`backup_models\` loop at \`incremental_engine.py:552\` raises \`TypeError\` on PA instances.
- Replace PA in \`backup_models\` with the sklearn-recommended substitute: \`SGDRegressor(loss='epsilon_insensitive', penalty=None, learning_rate='pa1', eta0=1.0)\`. Now every model in the loop accepts \`sample_weight\`, preserving the reliability-weighting feature.
- Guard \`realtime_feedback.update_model_incremental\` — \`current_model\` is loaded dynamically from disk, so wrap \`partial_fit(..., sample_weight=...)\` in a \`try/except TypeError\` that retries without weights. Protects against any older serialized PA model.

## Test plan
- [x] \`python manage.py test analyzer.ml\` → 341 pass (was passing; this fix prevents future breakage as the deprecation matures)
- [ ] sklearn major bump (Dependabot #43) can be unblocked after this lands