### PR TITLE
chore(deps): drop unused django-crispy-forms

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -12,7 +12,6 @@ scikit-learn>=1.5.0
 numpy>=1.21.0
 whitenoise==6.2.0
 sqlparse>=0.4.2
-django-crispy-forms>=2.6
 djangorestframework>=3.14.0
 djangorestframework-simplejwt>=5.2.0
 celery>=5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ numpy>=1.21.0
 matplotlib>=3.10.9
 whitenoise==6.2.0
 sqlparse>=0.4.2
-django-crispy-forms>=2.6
 djangorestframework>=3.14.0
 djangorestframework-simplejwt>=5.2.0
 celery>=5.2.0


### PR DESCRIPTION
## Summary
- Mirror of #65 (django-security removal). \`django-crispy-forms\` is listed in \`requirements.txt\` and \`requirements-prod.txt\` but has **zero usages** in the codebase — no \`{% crispy %}\` template tags, no \`{% load crispy_forms_tags %}\`, no Python imports, not in \`INSTALLED_APPS\`.
- The Dependabot bump (#49) just bumped a dead dependency from 1.14 → 2.6 last week; removing outright avoids the future bump churn and a few MB of install cost.

## Test plan
- [ ] CI green (or admin-merge consistent with prior dead-dep removal)
- [ ] No template regressions — confirmed via \`grep -rn crispy analyzer/ querygrade/\` returning zero hits