### PR TITLE
feat(ml): monitoring task + Celery Beat service (issue #5, PR 2/5)

### DIFF
--- a/Dockerfile.beat
+++ b/Dockerfile.beat
@@ -1,0 +1,31 @@
+# Celery Beat scheduler. Lightweight — beat only emits scheduled tasks; the
+# worker (Dockerfile.worker) executes them. So this image deliberately uses
+# the slim prod deps set (no torch/tensorflow/transformers), keeping the
+# beat service cheap and fast to redeploy.
+#
+# Issue #5 (ML Monitoring): beat fires `analyzer.tasks.monitor_ml_models`
+# every 15 min; see `querygrade/celery.py:beat_schedule`.
+FROM python:3.11-slim-bookworm
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements-prod.txt ./
+RUN pip install -r requirements-prod.txt
+
+COPY . .
+
+# `-S` schedules with a persistent shelf file so a beat restart doesn't
+# replay missed ticks. Persist to /tmp (Railway's writable scratch).
+CMD ["celery", "-A", "querygrade", "beat", "--loglevel=info", \
+     "-s", "/tmp/celerybeat-schedule"]

--- a/analyzer/management/commands/monitor_models.py
+++ b/analyzer/management/commands/monitor_models.py
@@ -1,0 +1,37 @@
+"""
+Periodic ML monitoring entrypoint.
+
+Runs all existing detectors (concept drift, data drift, performance
+degradation, low confidence, time-based) against the currently-ACTIVE
+HYBRID_SCORER and persists each surfaced trigger as an MLAlert row.
+
+Intended to be invoked every ~15 min via Celery Beat (see
+`querygrade/celery.py:beat_schedule`). Safe to run by hand at any
+time — the alert_evaluator dedupes against open alerts in the same
+(model, alert_type) raised in the last hour, so manual runs alongside
+the scheduled task won't double up.
+"""
+
+from django.core.management.base import BaseCommand
+
+from analyzer.ml.monitoring.alert_evaluator import run_evaluation
+
+
+class Command(BaseCommand):
+    help = (
+        "Run ML monitoring detectors and persist any surfaced triggers as MLAlert rows."
+    )
+
+    def handle(self, *args, **options):
+        created, skipped = run_evaluation()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Monitoring run complete: created {len(created)} alert(s), "
+                f"skipped {skipped} duplicate(s)."
+            )
+        )
+        for alert in created:
+            self.stdout.write(
+                f"  [{alert.severity}] {alert.get_alert_type_display()} — {alert.message[:80]}"
+            )

--- a/analyzer/ml/monitoring/alert_evaluator.py
+++ b/analyzer/ml/monitoring/alert_evaluator.py
@@ -1,0 +1,170 @@
+"""
+Glue between the existing ML detectors and the MLAlert model.
+
+The existing `ConfidenceBasedRetrainingSystem.evaluate_retraining_need()`
+returns a list of `RetrainingTrigger` dataclass instances. This module
+translates them into persisted `MLAlert` rows, deduped against any open
+alert of the same (model, alert_type) raised within the last hour.
+
+Keeping the translation in one place means the management command, the
+Celery task, and any future re-use (e.g., a manual "run evaluation now"
+button) all see the same alert semantics.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, is_dataclass
+from datetime import timedelta
+from typing import List, Optional, Tuple
+
+from django.utils import timezone
+
+from analyzer.ml.monitoring.retraining_system import (
+    ConfidenceBasedRetrainingSystem,
+    RetrainingTrigger,
+    TriggerReason,
+    TriggerUrgency,
+)
+from analyzer.models import MLAlert, MLModel
+
+logger = logging.getLogger(__name__)
+
+
+REASON_TO_ALERT_TYPE = {
+    TriggerReason.LOW_CONFIDENCE: "CONFIDENCE",
+    TriggerReason.PERFORMANCE_DEGRADATION: "PERFORMANCE",
+    TriggerReason.DATA_DRIFT: "DATA_DRIFT",
+    TriggerReason.FEEDBACK_DIVERGENCE: "USER_AGREEMENT",
+    TriggerReason.TIME_BASED: "TIME_BASED",
+    TriggerReason.EMERGENCY: "PERFORMANCE",
+    TriggerReason.MANUAL_OVERRIDE: "TIME_BASED",
+}
+
+URGENCY_TO_SEVERITY = {
+    TriggerUrgency.LOW: "LOW",
+    TriggerUrgency.MEDIUM: "MEDIUM",
+    TriggerUrgency.HIGH: "HIGH",
+    TriggerUrgency.CRITICAL: "CRITICAL",
+}
+
+DEDUPE_WINDOW = timedelta(hours=1)
+
+
+def _serialize_evidence(evidence: dict) -> dict:
+    """RetrainingTrigger.evidence can contain dataclass values — coerce to JSON-safe."""
+    safe = {}
+    for key, value in (evidence or {}).items():
+        if is_dataclass(value):
+            safe[key] = asdict(value)
+        elif isinstance(value, (str, int, float, bool, list, dict)) or value is None:
+            safe[key] = value
+        else:
+            safe[key] = str(value)
+    return safe
+
+
+def _active_target_model() -> Optional[MLModel]:
+    """The model these alerts get attached to.
+
+    Per CLAUDE.md, the production grading path uses an ACTIVE HYBRID_SCORER.
+    If none is active yet (fresh deploy), fall back to the most recently
+    deployed ACTIVE model of any type so alerts still attach to something
+    real.
+    """
+    target = (
+        MLModel.objects.filter(model_type="HYBRID_SCORER", status="ACTIVE")
+        .order_by("-deployed_at", "-created_at")
+        .first()
+    )
+    if target is None:
+        target = (
+            MLModel.objects.filter(status="ACTIVE")
+            .order_by("-deployed_at", "-created_at")
+            .first()
+        )
+    return target
+
+
+def _recent_open_alert_exists(model: MLModel, alert_type: str) -> bool:
+    cutoff = timezone.now() - DEDUPE_WINDOW
+    return MLAlert.objects.filter(
+        model=model,
+        alert_type=alert_type,
+        status="OPEN",
+        created_at__gte=cutoff,
+    ).exists()
+
+
+def trigger_to_alert(trigger: RetrainingTrigger, model: MLModel) -> Optional[MLAlert]:
+    """Persist a single RetrainingTrigger as an MLAlert. Returns the new alert
+    or None if a recent open alert already covers the same model+type."""
+    alert_type = REASON_TO_ALERT_TYPE.get(trigger.reason)
+    severity = URGENCY_TO_SEVERITY.get(trigger.urgency, "MEDIUM")
+
+    if alert_type is None:
+        logger.warning(
+            "Unmapped trigger reason %s — skipping alert creation", trigger.reason
+        )
+        return None
+
+    if _recent_open_alert_exists(model, alert_type):
+        logger.debug(
+            "Skipping duplicate alert: model=%s type=%s (dedupe window %s)",
+            model.pk,
+            alert_type,
+            DEDUPE_WINDOW,
+        )
+        return None
+
+    payload = {
+        "trigger_id": trigger.trigger_id,
+        "reason": trigger.reason.value,
+        "urgency": trigger.urgency.name,
+        "confidence_score": trigger.confidence_score,
+        "estimated_improvement": trigger.estimated_improvement,
+        "evidence": _serialize_evidence(trigger.evidence),
+        "cost_estimate": trigger.cost_estimate or {},
+    }
+
+    return MLAlert.objects.create(
+        model=model,
+        alert_type=alert_type,
+        severity=severity,
+        message=trigger.recommendation[:500],
+        payload=payload,
+    )
+
+
+def run_evaluation() -> Tuple[List[MLAlert], int]:
+    """Run a full monitoring evaluation, persist new alerts, return them.
+
+    Returns (created_alerts, skipped_count). The skipped count tracks how
+    many triggers were deduped against a recent open alert — useful for
+    monitoring task logging without leaking warnings on every healthy run.
+    """
+    target = _active_target_model()
+    if target is None:
+        logger.info("No ACTIVE MLModel found; skipping evaluation.")
+        return [], 0
+
+    system = ConfidenceBasedRetrainingSystem()
+    triggers = system.evaluate_retraining_need()
+
+    created: List[MLAlert] = []
+    skipped = 0
+    for trigger in triggers:
+        alert = trigger_to_alert(trigger, target)
+        if alert is None:
+            skipped += 1
+        else:
+            created.append(alert)
+
+    logger.info(
+        "Evaluation complete: triggers=%d, created=%d, skipped=%d, target_model=%s",
+        len(triggers),
+        len(created),
+        skipped,
+        target,
+    )
+    return created, skipped

--- a/analyzer/ml/tests/test_monitor_models.py
+++ b/analyzer/ml/tests/test_monitor_models.py
@@ -1,0 +1,254 @@
+"""
+Tests for the periodic ML monitoring entrypoint.
+
+Covers the alert_evaluator (trigger → MLAlert translation + dedupe)
+and the `monitor_models` management command. The underlying
+ConfidenceBasedRetrainingSystem is mocked to keep these tests fast
+and deterministic; that class has its own coverage elsewhere.
+"""
+
+from datetime import timedelta
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from analyzer.ml.monitoring import alert_evaluator
+from analyzer.ml.monitoring.retraining_system import (
+    RetrainingTrigger,
+    TriggerReason,
+    TriggerUrgency,
+)
+from analyzer.models import MLAlert, MLModel
+
+
+def _make_trigger(
+    reason: TriggerReason = TriggerReason.PERFORMANCE_DEGRADATION,
+    urgency: TriggerUrgency = TriggerUrgency.HIGH,
+    recommendation: str = "Retrain recommended due to performance drop.",
+):
+    return RetrainingTrigger(
+        trigger_id=f"trig_{reason.value}_{urgency.name}",
+        reason=reason,
+        urgency=urgency,
+        confidence_score=0.42,
+        evidence={"baseline_accuracy": 0.91, "current_accuracy": 0.74},
+        recommendation=recommendation,
+        estimated_improvement=0.12,
+        cost_estimate={"compute_minutes": 30},
+        timestamp=timezone.now(),
+    )
+
+
+class AlertEvaluatorTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.model = MLModel.objects.create(
+            name="HybridScorer",
+            model_type="HYBRID_SCORER",
+            version="1.0.0",
+            status="ACTIVE",
+            file_path="/tmp/dummy.joblib",
+            checksum="0" * 64,
+        )
+
+    def test_no_active_model_returns_empty(self):
+        # Deactivate the only model
+        MLModel.objects.update(status="DEPRECATED")
+        with patch.object(
+            alert_evaluator.ConfidenceBasedRetrainingSystem,
+            "evaluate_retraining_need",
+            return_value=[_make_trigger()],
+        ):
+            created, skipped = alert_evaluator.run_evaluation()
+        self.assertEqual(created, [])
+        self.assertEqual(skipped, 0)
+        self.assertEqual(MLAlert.objects.count(), 0)
+
+    def test_creates_alert_from_trigger(self):
+        with patch.object(
+            alert_evaluator.ConfidenceBasedRetrainingSystem,
+            "evaluate_retraining_need",
+            return_value=[_make_trigger()],
+        ):
+            created, skipped = alert_evaluator.run_evaluation()
+
+        self.assertEqual(len(created), 1)
+        self.assertEqual(skipped, 0)
+        alert = created[0]
+        self.assertEqual(alert.alert_type, "PERFORMANCE")
+        self.assertEqual(alert.severity, "HIGH")
+        self.assertEqual(alert.model, self.model)
+        self.assertIn("Retrain recommended", alert.message)
+        self.assertEqual(alert.payload["reason"], "performance_degradation")
+        self.assertEqual(alert.payload["urgency"], "HIGH")
+
+    def test_dedupes_within_window(self):
+        triggers = [_make_trigger(), _make_trigger()]
+        with patch.object(
+            alert_evaluator.ConfidenceBasedRetrainingSystem,
+            "evaluate_retraining_need",
+            return_value=triggers,
+        ):
+            created, skipped = alert_evaluator.run_evaluation()
+
+        # First trigger creates an alert, second is deduped against it
+        self.assertEqual(len(created), 1)
+        self.assertEqual(skipped, 1)
+        self.assertEqual(MLAlert.objects.count(), 1)
+
+    def test_dedupe_only_applies_to_open_alerts(self):
+        # Pre-existing RESOLVED alert of same type shouldn't block a new OPEN one
+        MLAlert.objects.create(
+            model=self.model,
+            alert_type="PERFORMANCE",
+            severity="MEDIUM",
+            status="RESOLVED",
+            message="Previously resolved.",
+        )
+        with patch.object(
+            alert_evaluator.ConfidenceBasedRetrainingSystem,
+            "evaluate_retraining_need",
+            return_value=[_make_trigger()],
+        ):
+            created, skipped = alert_evaluator.run_evaluation()
+        self.assertEqual(len(created), 1)
+        self.assertEqual(skipped, 0)
+
+    def test_dedupe_window_expires_after_an_hour(self):
+        # Open alert older than 1h should not block a new one
+        stale = MLAlert.objects.create(
+            model=self.model,
+            alert_type="PERFORMANCE",
+            severity="HIGH",
+            status="OPEN",
+            message="Stale open alert.",
+        )
+        # Bypass auto_now_add by direct update
+        MLAlert.objects.filter(pk=stale.pk).update(
+            created_at=timezone.now() - timedelta(hours=2)
+        )
+
+        with patch.object(
+            alert_evaluator.ConfidenceBasedRetrainingSystem,
+            "evaluate_retraining_need",
+            return_value=[_make_trigger()],
+        ):
+            created, skipped = alert_evaluator.run_evaluation()
+        self.assertEqual(len(created), 1)
+        self.assertEqual(skipped, 0)
+
+    def test_each_reason_maps_to_alert_type(self):
+        cases = [
+            (TriggerReason.LOW_CONFIDENCE, "CONFIDENCE"),
+            (TriggerReason.PERFORMANCE_DEGRADATION, "PERFORMANCE"),
+            (TriggerReason.DATA_DRIFT, "DATA_DRIFT"),
+            (TriggerReason.FEEDBACK_DIVERGENCE, "USER_AGREEMENT"),
+            (TriggerReason.TIME_BASED, "TIME_BASED"),
+        ]
+        for reason, expected_type in cases:
+            MLAlert.objects.all().delete()  # clear dedupe state per case
+            with patch.object(
+                alert_evaluator.ConfidenceBasedRetrainingSystem,
+                "evaluate_retraining_need",
+                return_value=[_make_trigger(reason=reason)],
+            ):
+                created, _ = alert_evaluator.run_evaluation()
+            self.assertEqual(len(created), 1, f"reason={reason}")
+            self.assertEqual(created[0].alert_type, expected_type, f"reason={reason}")
+
+    def test_urgency_maps_to_severity(self):
+        cases = [
+            (TriggerUrgency.LOW, "LOW"),
+            (TriggerUrgency.MEDIUM, "MEDIUM"),
+            (TriggerUrgency.HIGH, "HIGH"),
+            (TriggerUrgency.CRITICAL, "CRITICAL"),
+        ]
+        for urgency, expected_severity in cases:
+            MLAlert.objects.all().delete()
+            with patch.object(
+                alert_evaluator.ConfidenceBasedRetrainingSystem,
+                "evaluate_retraining_need",
+                return_value=[_make_trigger(urgency=urgency)],
+            ):
+                created, _ = alert_evaluator.run_evaluation()
+            self.assertEqual(created[0].severity, expected_severity)
+
+    def test_recommendation_truncated_to_500_chars(self):
+        long_rec = "X" * 800
+        with patch.object(
+            alert_evaluator.ConfidenceBasedRetrainingSystem,
+            "evaluate_retraining_need",
+            return_value=[_make_trigger(recommendation=long_rec)],
+        ):
+            created, _ = alert_evaluator.run_evaluation()
+        self.assertEqual(len(created[0].message), 500)
+
+
+class MonitorModelsCommandTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.model = MLModel.objects.create(
+            name="HybridScorer",
+            model_type="HYBRID_SCORER",
+            version="1.0.0",
+            status="ACTIVE",
+            file_path="/tmp/dummy.joblib",
+            checksum="0" * 64,
+        )
+
+    def test_command_runs_clean_with_no_triggers(self):
+        out = StringIO()
+        with patch.object(
+            alert_evaluator.ConfidenceBasedRetrainingSystem,
+            "evaluate_retraining_need",
+            return_value=[],
+        ):
+            call_command("monitor_models", stdout=out)
+        self.assertIn("created 0 alert(s)", out.getvalue())
+        self.assertEqual(MLAlert.objects.count(), 0)
+
+    def test_command_creates_alerts(self):
+        out = StringIO()
+        triggers = [
+            _make_trigger(
+                reason=TriggerReason.LOW_CONFIDENCE, urgency=TriggerUrgency.MEDIUM
+            ),
+            _make_trigger(
+                reason=TriggerReason.DATA_DRIFT, urgency=TriggerUrgency.CRITICAL
+            ),
+        ]
+        with patch.object(
+            alert_evaluator.ConfidenceBasedRetrainingSystem,
+            "evaluate_retraining_need",
+            return_value=triggers,
+        ):
+            call_command("monitor_models", stdout=out)
+        self.assertEqual(MLAlert.objects.count(), 2)
+        self.assertIn("created 2 alert(s)", out.getvalue())
+
+    def test_celery_task_wrapper(self):
+        from analyzer.tasks.monitoring_tasks import monitor_ml_models
+
+        with patch.object(
+            alert_evaluator.ConfidenceBasedRetrainingSystem,
+            "evaluate_retraining_need",
+            return_value=[_make_trigger()],
+        ):
+            result = monitor_ml_models()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["created"], 1)
+        self.assertEqual(result["skipped"], 0)
+
+    def test_celery_task_handles_exception(self):
+        from analyzer.tasks.monitoring_tasks import monitor_ml_models
+
+        with patch(
+            "analyzer.ml.monitoring.alert_evaluator.run_evaluation",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = monitor_ml_models()
+        self.assertEqual(result["status"], "error")
+        self.assertIn("boom", result["error"])

--- a/analyzer/tasks/__init__.py
+++ b/analyzer/tasks/__init__.py
@@ -22,6 +22,9 @@ from .log_tasks import process_log_file_async
 # Maintenance tasks
 from .maintenance_tasks import cleanup_temp_files
 
+# ML monitoring tasks
+from .monitoring_tasks import monitor_ml_models
+
 # Query analysis tasks
 from .query_tasks import batch_analyze_queries
 
@@ -42,4 +45,6 @@ __all__ = [
     "cleanup_temp_files",
     # Report tasks
     "generate_performance_report",
+    # ML monitoring tasks
+    "monitor_ml_models",
 ]

--- a/analyzer/tasks/monitoring_tasks.py
+++ b/analyzer/tasks/monitoring_tasks.py
@@ -1,0 +1,43 @@
+"""
+Celery tasks for periodic ML monitoring.
+
+These are thin wrappers around the management-command logic so the same
+code runs whether invoked by Beat, manually via `manage.py`, or imported
+directly from a view (e.g., a future "run evaluation now" button).
+"""
+
+import logging
+from typing import Any, Dict
+
+from celery import shared_task
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(name="analyzer.tasks.monitor_ml_models")
+def monitor_ml_models() -> Dict[str, Any]:
+    """Periodic monitoring task. Wired into Celery Beat in querygrade/celery.py."""
+    from analyzer.ml.monitoring.alert_evaluator import run_evaluation
+
+    try:
+        created, skipped = run_evaluation()
+        logger.info("monitor_ml_models: created=%d skipped=%d", len(created), skipped)
+        return {
+            "status": "success",
+            "created": len(created),
+            "skipped": skipped,
+            "created_ids": [a.id for a in created],
+            "timestamp": timezone.now().isoformat(),
+        }
+    except Exception as exc:
+        # Never let monitoring failures take down the beat worker — log and
+        # return a structured error. Persistent failures will themselves
+        # eventually surface as ops-visible behavior (e.g., zero alerts over
+        # many days), and the worker logs carry the trace.
+        logger.exception("monitor_ml_models failed: %s", exc)
+        return {
+            "status": "error",
+            "error": str(exc),
+            "timestamp": timezone.now().isoformat(),
+        }

--- a/querygrade/celery.py
+++ b/querygrade/celery.py
@@ -1,6 +1,7 @@
 import os
 
 from celery import Celery
+from celery.schedules import crontab
 
 # Set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "querygrade.settings")
@@ -15,6 +16,19 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()
+
+
+# Beat schedule. Picked up only by the `celery beat` process — the worker
+# process ignores this. Beat runs as its own Railway service; see
+# Dockerfile.beat. Granularity is 15 min for ML monitoring (easily meets
+# the issue #5 SLA of "drift detected within 24h" and "alert response <5
+# min"; the alert is delivered synchronously on detection).
+app.conf.beat_schedule = {
+    "monitor-ml-models": {
+        "task": "analyzer.tasks.monitor_ml_models",
+        "schedule": crontab(minute="*/15"),
+    },
+}
 
 
 @app.task(bind=True, ignore_result=True)

--- a/railway.toml
+++ b/railway.toml
@@ -8,3 +8,15 @@ dockerfilePath = "Dockerfile.web"
 # and re-run collectstatic in startCommand so /app/staticfiles exists for whitenoise.
 preDeployCommand = "sh -c 'python manage.py migrate --noinput && python manage.py init_superuser'"
 startCommand = "sh -c 'python manage.py collectstatic --noinput && gunicorn querygrade.wsgi --log-file - --log-level info --bind 0.0.0.0:$PORT'"
+
+# ---------------------------------------------------------------------------
+# Sibling services (provisioned in the Railway dashboard, not via railway.toml):
+#
+#   querygrade-worker  — Dockerfile.worker — Celery worker, executes ML tasks
+#   querygrade-beat    — Dockerfile.beat   — Celery beat, schedules monitor_ml_models
+#                                            every 15 min (see querygrade/celery.py)
+#
+# Both services share the same env vars as the web service (DATABASE_URL,
+# REDIS_URL, etc.). Beat additionally needs ML_ALERT_RECIPIENTS once PR 3
+# of the issue-#5 stack lands.
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
PR 2 of the issue-#5 stack. Wires the existing detectors into a scheduled task that persists triggers as MLAlert rows (model added in #71). Email delivery (PR 3) and dashboard ack flow (PR 4/5) follow.

> ⚠️ **Stacked on #71** — review/merge #71 first, then this PR will go green on its own.

## Components

- **\`analyzer/ml/monitoring/alert_evaluator.py\`** — single source of truth for \`RetrainingTrigger\` → \`MLAlert\` translation. Maps trigger reasons → alert_type, urgencies → severity. Dedupes against open alerts of the same (model, alert_type) within the last hour. Attaches every alert to the currently-ACTIVE \`HYBRID_SCORER\` (falls back to most recently deployed ACTIVE model of any type for fresh deploys).

- **\`analyzer/management/commands/monitor_models.py\`** — \`manage.py monitor_models\` thin wrapper. Safe to run manually alongside the scheduled task (dedupe guard prevents overlap).

- **\`analyzer/tasks/monitoring_tasks.py\`** — Celery task \`analyzer.tasks.monitor_ml_models\`. Catches its own exceptions so monitoring failures don't take down beat.

- **\`querygrade/celery.py\`** — \`beat_schedule\` fires every 15 minutes via crontab. Meets issue #5's "drift within 24h" and "alert response <5 min" SLAs.

- **\`Dockerfile.beat\`** — new lightweight image; uses \`requirements-prod.txt\` (no torch/tensorflow) since beat only emits.

- **\`railway.toml\`** — documents the sibling worker + beat services (provisioned in Railway dashboard).

## Test plan

- [x] \`python manage.py test analyzer\` → **658 tests, 0 fail / 0 error / 14 skipped** (+12 new monitor tests)
- [x] \`black --check\` on all touched files
- [x] Test coverage: trigger → alert mapping for every reason/urgency, dedupe within 1h, dedupe respects RESOLVED state + expires after 1h, recommendation truncation, command output, Celery task success/error paths

## Deploy notes

After merge, provision the \`querygrade-beat\` service in the Railway dashboard pointing at \`Dockerfile.beat\` with the same env vars as worker. The worker service must already exist (it does, per \`Dockerfile.worker\`) to actually execute the task that beat emits.