### PR TITLE
feat(ml): email alert delivery + 4h throttle (issue #5, PR 3/5)

### DIFF
--- a/analyzer/ml/monitoring/alert_evaluator.py
+++ b/analyzer/ml/monitoring/alert_evaluator.py
@@ -137,12 +137,21 @@ def trigger_to_alert(trigger: RetrainingTrigger, model: MLModel) -> Optional[MLA
 
 
 def run_evaluation() -> Tuple[List[MLAlert], int]:
-    """Run a full monitoring evaluation, persist new alerts, return them.
+    """Run a full monitoring evaluation, persist new alerts, send emails,
+    return the new alerts.
 
     Returns (created_alerts, skipped_count). The skipped count tracks how
     many triggers were deduped against a recent open alert — useful for
     monitoring task logging without leaking warnings on every healthy run.
+
+    Email delivery is best-effort: the MLAlert row is persisted first, then
+    the notifier is called. Mail failures are logged but don't fail the
+    evaluation — the alert is still visible in the dashboard / admin.
     """
+    # Import here so settings/email backend init happens at call time, not
+    # at module import (matters for test isolation + the worker startup path).
+    from analyzer.ml.monitoring.alert_notifier import send_alert_email
+
     target = _active_target_model()
     if target is None:
         logger.info("No ACTIVE MLModel found; skipping evaluation.")
@@ -159,6 +168,12 @@ def run_evaluation() -> Tuple[List[MLAlert], int]:
             skipped += 1
         else:
             created.append(alert)
+            try:
+                send_alert_email(alert)
+            except Exception as exc:
+                logger.exception(
+                    "send_alert_email failed for alert id=%s: %s", alert.pk, exc
+                )
 
     logger.info(
         "Evaluation complete: triggers=%d, created=%d, skipped=%d, target_model=%s",

--- a/analyzer/ml/monitoring/alert_notifier.py
+++ b/analyzer/ml/monitoring/alert_notifier.py
@@ -1,0 +1,131 @@
+"""
+Email delivery for MLAlert rows raised by the monitor_models task.
+
+Single entry point: `send_alert_email(alert)`. Throttled at 4h per
+(recipient, model, alert_type) tuple via the default Django cache so a
+flapping detector doesn't pager-bomb operators. Throttling is a soft
+gate — failures (cache miss, mail backend down) fall through to a sync
+send rather than silently dropping the alert.
+
+Templates live in `analyzer/templates/analyzer/emails/ml_alert.{txt,html}`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from django.conf import settings
+from django.core.cache import cache
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import render_to_string
+
+from analyzer.models import MLAlert
+
+logger = logging.getLogger(__name__)
+
+
+THROTTLE_SECONDS = 4 * 60 * 60  # 4 hours per (recipient, model, alert_type)
+
+SEVERITY_SUBJECT_PREFIX = {
+    "CRITICAL": "[CRITICAL]",
+    "HIGH": "[HIGH]",
+    "MEDIUM": "[MEDIUM]",
+    "LOW": "[LOW]",
+}
+
+
+def _recipients() -> List[str]:
+    configured = list(getattr(settings, "ML_ALERT_RECIPIENTS", []) or [])
+    if configured:
+        return [r.strip() for r in configured if r.strip()]
+    fallback = getattr(settings, "DEFAULT_FROM_EMAIL", None)
+    return [fallback] if fallback else []
+
+
+def _throttle_key(recipient: str, alert: MLAlert) -> str:
+    return f"ml_alert_throttle:{recipient}:{alert.model_id}:{alert.alert_type}"
+
+
+def _is_throttled(recipient: str, alert: MLAlert) -> bool:
+    return cache.get(_throttle_key(recipient, alert)) is not None
+
+
+def _mark_throttled(recipient: str, alert: MLAlert) -> None:
+    cache.set(_throttle_key(recipient, alert), True, timeout=THROTTLE_SECONDS)
+
+
+def _alert_url(alert: MLAlert) -> str:
+    """Build a best-effort link to the dashboard alerts panel. The panel
+    lands in PR 5 of this stack; the URL is stable now so emails sent
+    in the meantime point at the right place once it ships."""
+    base = getattr(settings, "SITE_URL", "https://querygrade.com").rstrip("/")
+    return f"{base}/ml/alerts/{alert.pk}/"
+
+
+def send_alert_email(alert: MLAlert) -> int:
+    """Send `alert` to every configured recipient that isn't currently throttled.
+
+    Returns the number of emails actually sent (0–N). Designed to be called
+    from the monitor_models task immediately after MLAlert.save() — the
+    sync send keeps the issue-#5 alert-response SLA honest.
+    """
+    recipients = _recipients()
+    if not recipients:
+        logger.warning(
+            "MLAlert id=%s created but no recipients configured (ML_ALERT_RECIPIENTS empty + no DEFAULT_FROM_EMAIL); skipping email.",
+            alert.pk,
+        )
+        return 0
+
+    sendable = [r for r in recipients if not _is_throttled(r, alert)]
+    if not sendable:
+        logger.info(
+            "All recipients throttled for alert id=%s model=%s type=%s; skipping email.",
+            alert.pk,
+            alert.model_id,
+            alert.alert_type,
+        )
+        return 0
+
+    subject = (
+        f"{SEVERITY_SUBJECT_PREFIX.get(alert.severity, '[ALERT]')} "
+        f"{alert.get_alert_type_display()} — {alert.model.name}"
+    )
+
+    ctx = {
+        "alert": alert,
+        "model": alert.model,
+        "alert_url": _alert_url(alert),
+        "alert_type_display": alert.get_alert_type_display(),
+        "severity_display": alert.get_severity_display(),
+    }
+    text_body = render_to_string("analyzer/emails/ml_alert.txt", ctx)
+    html_body = render_to_string("analyzer/emails/ml_alert.html", ctx)
+
+    from_email = getattr(settings, "DEFAULT_FROM_EMAIL", None)
+    sent = 0
+    for recipient in sendable:
+        try:
+            msg = EmailMultiAlternatives(
+                subject=subject,
+                body=text_body,
+                from_email=from_email,
+                to=[recipient],
+            )
+            msg.attach_alternative(html_body, "text/html")
+            msg.send(fail_silently=False)
+            _mark_throttled(recipient, alert)
+            sent += 1
+        except Exception as exc:
+            # One bad recipient shouldn't poison the rest. The MLAlert row
+            # is already persisted, so this email failure is recoverable —
+            # the dashboard surface still shows the alert.
+            logger.exception(
+                "Failed to send MLAlert email to %s for alert id=%s: %s",
+                recipient,
+                alert.pk,
+                exc,
+            )
+
+    return sent

--- a/analyzer/ml/tests/test_alert_notifier.py
+++ b/analyzer/ml/tests/test_alert_notifier.py
@@ -1,0 +1,232 @@
+"""
+Tests for ML alert email delivery (issue #5, PR 3).
+
+Uses Django's locmem mail backend (the test runner default) and
+DummyCache to keep throttling state isolated per test.
+"""
+
+from unittest.mock import patch
+
+from django.core import mail
+from django.test import TestCase, override_settings
+
+from analyzer.ml.monitoring.alert_notifier import (
+    THROTTLE_SECONDS,
+    send_alert_email,
+)
+from analyzer.models import MLAlert, MLModel
+
+
+@override_settings(
+    CACHES={
+        "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+    },
+    ML_ALERT_RECIPIENTS=["ops@example.com"],
+    DEFAULT_FROM_EMAIL="alerts@querygrade.com",
+    SITE_URL="https://querygrade.test",
+)
+class SendAlertEmailTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.model = MLModel.objects.create(
+            name="HybridScorer",
+            model_type="HYBRID_SCORER",
+            version="1.0.0",
+            status="ACTIVE",
+            file_path="/tmp/dummy.joblib",
+            checksum="0" * 64,
+        )
+
+    def _make_alert(self, alert_type="PERFORMANCE", severity="HIGH"):
+        return MLAlert.objects.create(
+            model=self.model,
+            alert_type=alert_type,
+            severity=severity,
+            message="Accuracy dropped from 0.91 to 0.74.",
+            payload={
+                "evidence": {"baseline": 0.91, "current": 0.74},
+                "estimated_improvement": 0.12,
+            },
+        )
+
+    def setUp(self):
+        # Reset locmem mail outbox each test
+        mail.outbox = []
+        # Clear throttle cache
+        from django.core.cache import cache
+
+        cache.clear()
+
+    def test_sends_to_configured_recipient(self):
+        alert = self._make_alert()
+        sent = send_alert_email(alert)
+        self.assertEqual(sent, 1)
+        self.assertEqual(len(mail.outbox), 1)
+
+        msg = mail.outbox[0]
+        self.assertEqual(msg.to, ["ops@example.com"])
+        self.assertEqual(msg.from_email, "alerts@querygrade.com")
+        self.assertIn("[HIGH]", msg.subject)
+        self.assertIn("Performance degradation", msg.subject)
+        self.assertIn("HybridScorer", msg.subject)
+
+    def test_text_body_includes_key_fields(self):
+        alert = self._make_alert(severity="CRITICAL")
+        send_alert_email(alert)
+        body = mail.outbox[0].body
+        self.assertIn("Critical", body)
+        self.assertIn("HybridScorer v1.0.0", body)
+        self.assertIn("Accuracy dropped", body)
+        self.assertIn("https://querygrade.test/ml/alerts/", body)
+        self.assertIn(str(alert.pk), body)
+
+    def test_html_alternative_attached(self):
+        alert = self._make_alert()
+        send_alert_email(alert)
+        msg = mail.outbox[0]
+        self.assertTrue(
+            any(content_type == "text/html" for _, content_type in msg.alternatives)
+        )
+
+    def test_throttle_blocks_repeat_within_window(self):
+        alert = self._make_alert()
+        first = send_alert_email(alert)
+        second = send_alert_email(alert)
+        self.assertEqual(first, 1)
+        self.assertEqual(second, 0)
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_throttle_is_per_recipient(self):
+        with override_settings(
+            ML_ALERT_RECIPIENTS=["a@example.com", "b@example.com"],
+        ):
+            alert = self._make_alert()
+            sent = send_alert_email(alert)
+            self.assertEqual(sent, 2)
+            # Same alert again — both throttled now
+            sent_again = send_alert_email(alert)
+            self.assertEqual(sent_again, 0)
+
+    def test_different_alert_type_not_throttled(self):
+        a = self._make_alert(alert_type="PERFORMANCE")
+        b = self._make_alert(alert_type="DATA_DRIFT")
+        send_alert_email(a)
+        send_alert_email(b)
+        self.assertEqual(len(mail.outbox), 2)
+
+    def test_falls_back_to_default_from_email_when_recipients_empty(self):
+        with override_settings(ML_ALERT_RECIPIENTS=[]):
+            alert = self._make_alert()
+            sent = send_alert_email(alert)
+            self.assertEqual(sent, 1)
+            self.assertEqual(mail.outbox[0].to, ["alerts@querygrade.com"])
+
+    def test_no_recipients_at_all_skips_send(self):
+        with override_settings(ML_ALERT_RECIPIENTS=[], DEFAULT_FROM_EMAIL=""):
+            alert = self._make_alert()
+            sent = send_alert_email(alert)
+            self.assertEqual(sent, 0)
+            self.assertEqual(len(mail.outbox), 0)
+
+    def test_individual_recipient_failure_doesnt_block_others(self):
+        with override_settings(
+            ML_ALERT_RECIPIENTS=["bad@example.com", "ok@example.com"],
+        ):
+            alert = self._make_alert()
+            real_send = mail.EmailMultiAlternatives.send
+
+            def selective_send(self_, *args, **kwargs):
+                if "bad@example.com" in self_.to:
+                    raise RuntimeError("SMTP rejected")
+                return real_send(self_, *args, **kwargs)
+
+            with patch.object(mail.EmailMultiAlternatives, "send", selective_send):
+                sent = send_alert_email(alert)
+            self.assertEqual(sent, 1)  # only ok@ succeeded
+
+    def test_subject_prefix_per_severity(self):
+        cases = {
+            "LOW": "[LOW]",
+            "MEDIUM": "[MEDIUM]",
+            "HIGH": "[HIGH]",
+            "CRITICAL": "[CRITICAL]",
+        }
+        for severity, prefix in cases.items():
+            mail.outbox = []
+            from django.core.cache import cache
+
+            cache.clear()
+            alert = self._make_alert(severity=severity)
+            send_alert_email(alert)
+            self.assertEqual(len(mail.outbox), 1)
+            self.assertTrue(mail.outbox[0].subject.startswith(prefix))
+
+
+@override_settings(
+    CACHES={
+        "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+    },
+    ML_ALERT_RECIPIENTS=["ops@example.com"],
+)
+class EvaluatorEmailIntegrationTests(TestCase):
+    """run_evaluation() should send mail for each newly-created alert."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.model = MLModel.objects.create(
+            name="HybridScorer",
+            model_type="HYBRID_SCORER",
+            version="1.0.0",
+            status="ACTIVE",
+            file_path="/tmp/dummy.joblib",
+            checksum="0" * 64,
+        )
+
+    def setUp(self):
+        mail.outbox = []
+        from django.core.cache import cache
+
+        cache.clear()
+
+    def test_evaluation_sends_one_email_per_new_alert(self):
+        from analyzer.ml.monitoring import alert_evaluator
+        from analyzer.ml.monitoring.retraining_system import (
+            RetrainingTrigger,
+            TriggerReason,
+            TriggerUrgency,
+        )
+        from django.utils import timezone as dj_timezone
+
+        triggers = [
+            RetrainingTrigger(
+                trigger_id="t1",
+                reason=TriggerReason.PERFORMANCE_DEGRADATION,
+                urgency=TriggerUrgency.HIGH,
+                confidence_score=0.4,
+                evidence={"baseline": 0.9, "current": 0.7},
+                recommendation="Retrain due to perf drop.",
+                estimated_improvement=0.15,
+                cost_estimate={},
+                timestamp=dj_timezone.now(),
+            ),
+            RetrainingTrigger(
+                trigger_id="t2",
+                reason=TriggerReason.DATA_DRIFT,
+                urgency=TriggerUrgency.CRITICAL,
+                confidence_score=0.3,
+                evidence={"ks_stat": 0.42},
+                recommendation="Feature distribution shifted.",
+                estimated_improvement=0.1,
+                cost_estimate={},
+                timestamp=dj_timezone.now(),
+            ),
+        ]
+        with patch.object(
+            alert_evaluator.ConfidenceBasedRetrainingSystem,
+            "evaluate_retraining_need",
+            return_value=triggers,
+        ):
+            created, skipped = alert_evaluator.run_evaluation()
+        self.assertEqual(len(created), 2)
+        self.assertEqual(skipped, 0)
+        self.assertEqual(len(mail.outbox), 2)

--- a/analyzer/templates/analyzer/emails/ml_alert.html
+++ b/analyzer/templates/analyzer/emails/ml_alert.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ML alert: {{ alert_type_display }}</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #1f2937; max-width: 640px; margin: 0 auto; padding: 24px;">
+
+  <div style="padding: 12px 16px; border-radius: 6px; margin-bottom: 16px;
+              {% if alert.severity == 'CRITICAL' %}background:#fef2f2; border-left:4px solid #dc2626;
+              {% elif alert.severity == 'HIGH' %}background:#fff7ed; border-left:4px solid #ea580c;
+              {% elif alert.severity == 'MEDIUM' %}background:#fefce8; border-left:4px solid #ca8a04;
+              {% else %}background:#f0fdf4; border-left:4px solid #16a34a;{% endif %}">
+    <div style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280; font-weight: 600;">
+      [{{ severity_display }}] ML alert
+    </div>
+    <div style="font-size: 18px; font-weight: 700; margin-top: 4px;">
+      {{ alert_type_display }} — {{ model.name }} v{{ model.version }}
+    </div>
+  </div>
+
+  <p style="font-size: 15px; line-height: 1.5;">{{ alert.message }}</p>
+
+  <table style="width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 14px;">
+    <tr style="background:#f9fafb;">
+      <td style="padding: 8px 12px; color: #6b7280; width: 30%;">Model</td>
+      <td style="padding: 8px 12px;">{{ model.name }} v{{ model.version }} ({{ model.get_model_type_display }})</td>
+    </tr>
+    <tr>
+      <td style="padding: 8px 12px; color: #6b7280;">Status</td>
+      <td style="padding: 8px 12px;">{{ model.get_status_display }}</td>
+    </tr>
+    <tr style="background:#f9fafb;">
+      <td style="padding: 8px 12px; color: #6b7280;">Severity</td>
+      <td style="padding: 8px 12px;">{{ severity_display }}</td>
+    </tr>
+    <tr>
+      <td style="padding: 8px 12px; color: #6b7280;">Raised</td>
+      <td style="padding: 8px 12px;">{{ alert.created_at|date:"Y-m-d H:i T" }}</td>
+    </tr>
+    {% if alert.payload.estimated_improvement %}
+    <tr style="background:#f9fafb;">
+      <td style="padding: 8px 12px; color: #6b7280;">Est. improvement</td>
+      <td style="padding: 8px 12px;">{{ alert.payload.estimated_improvement|floatformat:3 }} from retrain</td>
+    </tr>
+    {% endif %}
+  </table>
+
+  {% if alert.payload.evidence %}
+  <div style="margin: 20px 0;">
+    <div style="font-size: 13px; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em;">Evidence</div>
+    <ul style="margin: 8px 0 0 0; padding-left: 20px; font-size: 14px;">
+      {% for key, value in alert.payload.evidence.items %}
+      <li><span style="color: #6b7280;">{{ key }}:</span> {{ value }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+
+  <a href="{{ alert_url }}" style="display: inline-block; background:#4f46e5; color: white; padding: 10px 20px; border-radius: 6px; text-decoration: none; font-weight: 500; font-size: 14px; margin-top: 8px;">
+    Review &amp; triage →
+  </a>
+
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 28px 0 12px;">
+  <p style="font-size: 12px; color: #9ca3af; line-height: 1.5;">
+    QueryGrade ML monitoring — issue #5.
+    Further alerts of this same type for this same model will be suppressed
+    for 4 hours per recipient to avoid pager-bombing on a flapping detector.
+  </p>
+</body>
+</html>

--- a/analyzer/templates/analyzer/emails/ml_alert.txt
+++ b/analyzer/templates/analyzer/emails/ml_alert.txt
@@ -1,0 +1,26 @@
+[{{ severity_display }}] ML alert: {{ alert_type_display }} on {{ model.name }} v{{ model.version }}
+
+{{ alert.message }}
+
+──────────────────────────────────────────────────────────────────────
+Model:       {{ model.name }} v{{ model.version }} ({{ model.get_model_type_display }})
+Status:      {{ model.get_status_display }}
+Alert type:  {{ alert_type_display }}
+Severity:    {{ severity_display }}
+Raised at:   {{ alert.created_at|date:"Y-m-d H:i T" }}
+──────────────────────────────────────────────────────────────────────
+
+{% if alert.payload.evidence %}Evidence:
+{% for key, value in alert.payload.evidence.items %}  · {{ key }}: {{ value }}
+{% endfor %}{% endif %}{% if alert.payload.estimated_improvement %}
+Estimated improvement from retrain: {{ alert.payload.estimated_improvement|floatformat:3 }}
+{% endif %}
+
+Review and triage this alert:
+{{ alert_url }}
+
+──────────────────────────────────────────────────────────────────────
+QueryGrade ML monitoring — issue #5
+
+Further alerts of this same type for this same model will be suppressed
+for 4 hours per recipient to avoid pager-bombing on a flapping detector.

--- a/querygrade/settings.py
+++ b/querygrade/settings.py
@@ -293,6 +293,17 @@ EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "noreply@querygrade.com")
 
+# ML monitoring alerts (issue #5). Comma-separated recipient list; falls back
+# to DEFAULT_FROM_EMAIL if unset (which means the alert goes back to the same
+# inbox the system sends *from* — useful for staging, sufficient for a small
+# ops team in prod). Set via `railway variables --set "ML_ALERT_RECIPIENTS=..."`.
+ML_ALERT_RECIPIENTS = config("ML_ALERT_RECIPIENTS", default="", cast=Csv())
+
+# Base URL for absolute links in transactional email (e.g., the "Review and
+# triage" deep link in ML alert mail). Defaults to the production hostname
+# so alerts mailed from staging without this var still point at something real.
+SITE_URL = config("SITE_URL", default="https://querygrade.com")
+
 # Django REST Framework configuration
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [


### PR DESCRIPTION
PR 3 of the issue-#5 stack. When \`monitor_models\` persists a new \`MLAlert\`, mail it out immediately. PRs 4–5 add the dashboard ack flow and FPR widget.

## Components

- **\`analyzer/ml/monitoring/alert_notifier.py:send_alert_email(alert)\`** — formats subject/body, renders both text + HTML templates, sends via Django's \`EmailMultiAlternatives\`. Per-(recipient, model, alert_type) **4-hour throttle** via the default Django cache — a flapping detector can't pager-bomb anyone.

- **Templates** at \`analyzer/templates/analyzer/emails/ml_alert.{txt,html}\`. HTML version uses a left-border accent colored by severity (red/orange/yellow/green) and a CTA linking to the dashboard alert page (lands in PR 5; URL is stable now).

- **\`alert_evaluator.run_evaluation()\`** now calls \`send_alert_email\` for every newly-created alert. Mail failures are logged but never raise — the MLAlert row is already persisted, so the dashboard surface still shows the alert even if SMTP is down.

- **Settings additions** (\`querygrade/settings.py\`):
  - \`ML_ALERT_RECIPIENTS\` (Csv env var) — falls back to \`DEFAULT_FROM_EMAIL\` when unset
  - \`SITE_URL\` — base for absolute links in transactional email; defaults to https://querygrade.com

## Test plan

- [x] \`python manage.py test analyzer\` → **669 tests, 0 fail / 0 error / 14 skipped** (+11 new notifier tests)
- [x] \`black --check\` on all touched files
- [x] Coverage: send happy path, throttle, per-recipient + per-alert-type isolation, DEFAULT_FROM_EMAIL fallback, no-recipients no-op, partial recipient failure tolerance, severity subject prefix, run_evaluation integration

## Deploy notes

Set \`ML_ALERT_RECIPIENTS\` on the **worker** + **beat** services in Railway before this deploys — otherwise alerts route to \`DEFAULT_FROM_EMAIL\` which probably isn't useful as a destination.

\`\`\`bash
railway variables --service querygrade-worker --set "ML_ALERT_RECIPIENTS=ops@example.com,sre@example.com"
railway variables --service querygrade-beat   --set "ML_ALERT_RECIPIENTS=ops@example.com,sre@example.com"
\`\`\`