### PR TITLE
feat(ml): alert ack/dismiss/FP + safety-guarded rollback (issue #5, PR 4/5)

### DIFF
--- a/analyzer/ml/monitoring/rollback.py
+++ b/analyzer/ml/monitoring/rollback.py
@@ -1,0 +1,146 @@
+"""
+Manual rollback to a previous ML model version, with safety guards.
+
+Issue #5 explicitly scopes this as **operator-initiated**, not automatic —
+auto-rollback graduates only after the false-positive rate is proven <5%
+over a 30-day window. For now: the dashboard offers a button per active
+model, this helper validates + executes the swap.
+
+Guards (in order — first failure short-circuits):
+
+  1. Target model must be currently ACTIVE.
+  2. A prior version must exist (same model_type, lower version,
+     status DEPRECATED). If never had a prior ACTIVE version, refuse.
+  3. No other rollback for the same model_type within the last 24 h
+     (prevents thrash if the prior model is also bad).
+
+On success: atomic swap. Target → DEPRECATED, prior → ACTIVE.
+Audit row created as MLAlert(alert_type='ROLLBACK_PERFORMED',
+severity='HIGH', status='RESOLVED') attached to the rolled-back model.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Optional
+
+from django.contrib.auth.models import User
+from django.db import transaction
+from django.utils import timezone
+
+from analyzer.models import MLAlert, MLModel
+
+logger = logging.getLogger(__name__)
+
+ROLLBACK_COOLDOWN = timedelta(hours=24)
+
+
+class RollbackError(Exception):
+    """Raised when a rollback request fails a guard."""
+
+
+def _previous_deprecated(model: MLModel) -> Optional[MLModel]:
+    """The most recent DEPRECATED model of the same type, prior to `model`."""
+    return (
+        MLModel.objects.filter(model_type=model.model_type, status="DEPRECATED")
+        .exclude(pk=model.pk)
+        .order_by("-deployed_at", "-created_at")
+        .first()
+    )
+
+
+def _recent_rollback_exists(model_type: str) -> bool:
+    cutoff = timezone.now() - ROLLBACK_COOLDOWN
+    return MLAlert.objects.filter(
+        alert_type="ROLLBACK_PERFORMED",
+        model__model_type=model_type,
+        created_at__gte=cutoff,
+    ).exists()
+
+
+def perform_rollback(target: MLModel, performed_by: Optional[User] = None) -> MLAlert:
+    """Roll `target` back to its previous DEPRECATED version of the same type.
+
+    Returns the audit MLAlert row. Raises RollbackError on any guard failure.
+    """
+    if target.status != "ACTIVE":
+        raise RollbackError(
+            f"Cannot roll back: target model {target} is not ACTIVE "
+            f"(status={target.status})."
+        )
+
+    prior = _previous_deprecated(target)
+    if prior is None:
+        raise RollbackError(
+            f"Cannot roll back: no prior DEPRECATED {target.model_type} model exists."
+        )
+
+    if _recent_rollback_exists(target.model_type):
+        raise RollbackError(
+            f"Cannot roll back: another rollback for model_type "
+            f"{target.model_type} happened in the last 24 h. "
+            f"Manual intervention required."
+        )
+
+    now = timezone.now()
+    resolution = (
+        f"Manual rollback: {target.name} v{target.version} → "
+        f"{prior.name} v{prior.version}"
+        + (f" by {performed_by.username}" if performed_by else "")
+        + f" at {now.isoformat()}"
+    )
+
+    with transaction.atomic():
+        target.status = "DEPRECATED"
+        target.save(update_fields=["status"])
+
+        prior.status = "ACTIVE"
+        prior.deployed_at = now
+        prior.save(update_fields=["status", "deployed_at"])
+
+        audit = MLAlert.objects.create(
+            model=target,
+            alert_type="ROLLBACK_PERFORMED",
+            severity="HIGH",
+            status="RESOLVED",
+            message=f"Rolled back to {prior.name} v{prior.version}.",
+            resolution=resolution,
+            acknowledged_by=performed_by,
+            acknowledged_at=now,
+            payload={
+                "rolled_back_to": {
+                    "id": prior.id,
+                    "name": prior.name,
+                    "version": prior.version,
+                },
+                "rolled_back_from": {
+                    "id": target.id,
+                    "name": target.name,
+                    "version": target.version,
+                },
+            },
+        )
+
+    logger.warning(
+        "Rollback performed: %s v%s → %s v%s (by %s)",
+        target.name,
+        target.version,
+        prior.name,
+        prior.version,
+        performed_by.username if performed_by else "system",
+    )
+    return audit
+
+
+def can_rollback(target: MLModel) -> bool:
+    """Cheap pre-check used by the dashboard to decide whether to render
+    the rollback button. Mirrors perform_rollback's guards without
+    mutating any state."""
+    if target.status != "ACTIVE":
+        return False
+    if _previous_deprecated(target) is None:
+        return False
+    if _recent_rollback_exists(target.model_type):
+        return False
+    return True

--- a/analyzer/test_ml_alert_views.py
+++ b/analyzer/test_ml_alert_views.py
@@ -1,0 +1,278 @@
+"""
+Tests for ML alert ack/dismiss/false-positive views and the
+manual-rollback endpoint (issue #5, PR 4).
+
+Auth: all 4 endpoints require login + staff/superuser. Tests cover
+both the success paths and the safety guards on rollback.
+"""
+
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from analyzer.models import MLAlert, MLModel
+
+
+class AckDismissFalsePositiveTests(TestCase):
+    """Coverage for the three triage endpoints."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            username="ops", password="opspass123", is_staff=True
+        )
+        cls.regular = User.objects.create_user(
+            username="rando", password="randopass123"
+        )
+        cls.model = MLModel.objects.create(
+            name="HybridScorer",
+            model_type="HYBRID_SCORER",
+            version="2.0.0",
+            status="ACTIVE",
+            file_path="/tmp/dummy.joblib",
+            checksum="0" * 64,
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.alert = MLAlert.objects.create(
+            model=self.model,
+            alert_type="PERFORMANCE",
+            severity="HIGH",
+            message="Accuracy dropped.",
+        )
+
+    # ---- ack ----
+
+    def test_ack_requires_login(self):
+        url = reverse("ml_alert_ack", args=[self.alert.pk])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.url.startswith("/login/"))
+
+    def test_ack_requires_staff(self):
+        self.client.login(username="rando", password="randopass123")
+        url = reverse("ml_alert_ack", args=[self.alert.pk])
+        response = self.client.post(url)
+        # @user_passes_test redirects to LOGIN_URL on failure
+        self.assertEqual(response.status_code, 302)
+        # Status unchanged
+        self.alert.refresh_from_db()
+        self.assertEqual(self.alert.status, "OPEN")
+
+    def test_ack_get_not_allowed(self):
+        self.client.login(username="ops", password="opspass123")
+        response = self.client.get(reverse("ml_alert_ack", args=[self.alert.pk]))
+        self.assertEqual(response.status_code, 405)
+
+    def test_ack_open_alert_transitions_to_acknowledged(self):
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_alert_ack", args=[self.alert.pk])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.alert.refresh_from_db()
+        self.assertEqual(self.alert.status, "ACKNOWLEDGED")
+        self.assertEqual(self.alert.acknowledged_by, self.staff)
+        self.assertIsNotNone(self.alert.acknowledged_at)
+
+    def test_ack_idempotent_for_already_acknowledged(self):
+        self.alert.status = "ACKNOWLEDGED"
+        self.alert.acknowledged_by = self.staff
+        self.alert.acknowledged_at = timezone.now()
+        self.alert.save()
+        original_at = self.alert.acknowledged_at
+
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_alert_ack", args=[self.alert.pk])
+        self.client.post(url)
+        self.alert.refresh_from_db()
+        # Status unchanged, ack_at unchanged
+        self.assertEqual(self.alert.status, "ACKNOWLEDGED")
+        self.assertEqual(self.alert.acknowledged_at, original_at)
+
+    # ---- dismiss / resolve ----
+
+    def test_dismiss_resolves_with_optional_resolution(self):
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_alert_dismiss", args=[self.alert.pk])
+        response = self.client.post(url, {"resolution": "Hot-patched the index."})
+        self.assertEqual(response.status_code, 302)
+        self.alert.refresh_from_db()
+        self.assertEqual(self.alert.status, "RESOLVED")
+        self.assertEqual(self.alert.resolution, "Hot-patched the index.")
+        self.assertEqual(self.alert.acknowledged_by, self.staff)
+
+    def test_dismiss_skips_already_terminal(self):
+        self.alert.status = "FALSE_POSITIVE"
+        self.alert.save()
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_alert_dismiss", args=[self.alert.pk])
+        self.client.post(url)
+        self.alert.refresh_from_db()
+        self.assertEqual(self.alert.status, "FALSE_POSITIVE")  # unchanged
+
+    # ---- false positive ----
+
+    def test_mark_false_positive(self):
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_alert_false_positive", args=[self.alert.pk])
+        response = self.client.post(url, {"resolution": "Detector noise."})
+        self.assertEqual(response.status_code, 302)
+        self.alert.refresh_from_db()
+        self.assertEqual(self.alert.status, "FALSE_POSITIVE")
+        self.assertEqual(self.alert.resolution, "Detector noise.")
+
+    def test_false_positive_skips_already_terminal(self):
+        self.alert.status = "RESOLVED"
+        self.alert.save()
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_alert_false_positive", args=[self.alert.pk])
+        self.client.post(url)
+        self.alert.refresh_from_db()
+        self.assertEqual(self.alert.status, "RESOLVED")  # unchanged
+
+    def test_endpoint_404_for_missing_alert(self):
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_alert_ack", args=[999_999])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 404)
+
+
+class RollbackTests(TestCase):
+    """Coverage for the manual rollback endpoint + the safety guards in
+    `analyzer.ml.monitoring.rollback.perform_rollback`."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            username="ops", password="opspass123", is_staff=True
+        )
+
+    def setUp(self):
+        self.client = Client()
+        # Prior DEPRECATED version
+        self.prior = MLModel.objects.create(
+            name="HybridScorer",
+            model_type="HYBRID_SCORER",
+            version="1.0.0",
+            status="DEPRECATED",
+            file_path="/tmp/dummy-prior.joblib",
+            checksum="1" * 64,
+            deployed_at=timezone.now() - timedelta(days=30),
+        )
+        # Current ACTIVE version
+        self.current = MLModel.objects.create(
+            name="HybridScorer",
+            model_type="HYBRID_SCORER",
+            version="2.0.0",
+            status="ACTIVE",
+            file_path="/tmp/dummy-current.joblib",
+            checksum="2" * 64,
+            deployed_at=timezone.now() - timedelta(days=2),
+        )
+
+    def test_requires_staff(self):
+        self.client.login(
+            username=User.objects.create_user(username="r", password="p").username,
+            password="p",
+        )
+        url = reverse("ml_model_rollback", args=[self.current.pk])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.current.refresh_from_db()
+        self.assertEqual(self.current.status, "ACTIVE")  # untouched
+
+    def test_get_not_allowed(self):
+        self.client.login(username="ops", password="opspass123")
+        response = self.client.get(reverse("ml_model_rollback", args=[self.current.pk]))
+        self.assertEqual(response.status_code, 405)
+
+    def test_happy_path_swaps_statuses_and_creates_audit(self):
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_model_rollback", args=[self.current.pk])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+
+        self.current.refresh_from_db()
+        self.prior.refresh_from_db()
+        self.assertEqual(self.current.status, "DEPRECATED")
+        self.assertEqual(self.prior.status, "ACTIVE")
+
+        audit = MLAlert.objects.filter(alert_type="ROLLBACK_PERFORMED").first()
+        self.assertIsNotNone(audit)
+        self.assertEqual(audit.model, self.current)
+        self.assertEqual(audit.status, "RESOLVED")
+        self.assertEqual(audit.severity, "HIGH")
+        self.assertEqual(audit.acknowledged_by, self.staff)
+        self.assertIn("v1.0.0", audit.message)
+        self.assertEqual(audit.payload["rolled_back_to"]["version"], "1.0.0")
+        self.assertEqual(audit.payload["rolled_back_from"]["version"], "2.0.0")
+
+    def test_refuses_when_target_not_active(self):
+        self.current.status = "DEPRECATED"
+        self.current.save()
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_model_rollback", args=[self.current.pk])
+        self.client.post(url)
+        # No audit row was created
+        self.assertFalse(
+            MLAlert.objects.filter(alert_type="ROLLBACK_PERFORMED").exists()
+        )
+
+    def test_refuses_when_no_prior_version(self):
+        self.prior.delete()
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_model_rollback", args=[self.current.pk])
+        self.client.post(url)
+        self.current.refresh_from_db()
+        self.assertEqual(self.current.status, "ACTIVE")  # unchanged
+        self.assertFalse(
+            MLAlert.objects.filter(alert_type="ROLLBACK_PERFORMED").exists()
+        )
+
+    def test_refuses_when_recent_rollback_exists(self):
+        # Pre-existing rollback audit within cool-down window
+        MLAlert.objects.create(
+            model=self.current,
+            alert_type="ROLLBACK_PERFORMED",
+            severity="HIGH",
+            status="RESOLVED",
+            message="prior rollback",
+        )
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_model_rollback", args=[self.current.pk])
+        self.client.post(url)
+        self.current.refresh_from_db()
+        self.assertEqual(self.current.status, "ACTIVE")  # cool-down blocked
+
+    def test_cooldown_expires_after_24h(self):
+        recent = MLAlert.objects.create(
+            model=self.current,
+            alert_type="ROLLBACK_PERFORMED",
+            severity="HIGH",
+            status="RESOLVED",
+            message="prior rollback",
+        )
+        # Push it past the 24h cool-down
+        MLAlert.objects.filter(pk=recent.pk).update(
+            created_at=timezone.now() - timedelta(hours=25)
+        )
+        self.client.login(username="ops", password="opspass123")
+        url = reverse("ml_model_rollback", args=[self.current.pk])
+        self.client.post(url)
+        self.current.refresh_from_db()
+        self.prior.refresh_from_db()
+        self.assertEqual(self.current.status, "DEPRECATED")
+        self.assertEqual(self.prior.status, "ACTIVE")
+
+    def test_can_rollback_helper(self):
+        from analyzer.ml.monitoring.rollback import can_rollback
+
+        self.assertTrue(can_rollback(self.current))
+
+        # No prior
+        self.prior.delete()
+        self.assertFalse(can_rollback(self.current))

--- a/analyzer/urls.py
+++ b/analyzer/urls.py
@@ -9,6 +9,7 @@ from django.urls import path
 
 # ML Dashboard views (separate module)
 from .ml import dashboard_views
+from .views import ml_alert_views
 
 # Import from modular views package
 from .views import (  # Authentication views; Query grading views; Comparison views; Batch analysis views; History and feedback views; Upload views; Database introspection views; Async processing views; API views; Saved connection views
@@ -139,6 +140,27 @@ urlpatterns = [
         "ml/api/trigger-training/",
         dashboard_views.dashboard_api_trigger_training,
         name="ml_api_trigger_training",
+    ),
+    # ML alert triage (issue #5). List view ships in PR 5 of the stack.
+    path(
+        "ml/alerts/<int:alert_id>/ack/",
+        ml_alert_views.ack_alert,
+        name="ml_alert_ack",
+    ),
+    path(
+        "ml/alerts/<int:alert_id>/dismiss/",
+        ml_alert_views.dismiss_alert,
+        name="ml_alert_dismiss",
+    ),
+    path(
+        "ml/alerts/<int:alert_id>/false-positive/",
+        ml_alert_views.mark_false_positive,
+        name="ml_alert_false_positive",
+    ),
+    path(
+        "ml/models/<int:model_id>/rollback/",
+        ml_alert_views.rollback_model,
+        name="ml_model_rollback",
     ),
     # API endpoints
     path(

--- a/analyzer/views/ml_alert_views.py
+++ b/analyzer/views/ml_alert_views.py
@@ -1,0 +1,128 @@
+"""
+Views for ML alert triage and manual rollback (issue #5).
+
+POST-only mutating endpoints, staff-only. The list view (GET /ml/alerts/)
+ships in PR 5 — this PR adds the action endpoints so the dashboard panel
+in PR 5 has working buttons from day one.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required, user_passes_test
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse
+from django.utils import timezone
+from django.views.decorators.http import require_POST
+
+from analyzer.ml.monitoring.rollback import RollbackError, perform_rollback
+from analyzer.models import MLAlert, MLModel
+
+logger = logging.getLogger(__name__)
+
+
+def _is_staff_or_superuser(user) -> bool:
+    return user.is_staff or user.is_superuser
+
+
+def _redirect_back(request) -> HttpResponseRedirect:
+    """Send the operator back where they came from, or the dashboard."""
+    referrer = request.META.get("HTTP_REFERER")
+    if referrer:
+        return HttpResponseRedirect(referrer)
+    # ml_alerts route lands in PR 5; until then fall back to the dashboard
+    try:
+        return redirect("ml_alerts")
+    except Exception:
+        return redirect("ml_dashboard")
+
+
+def _set_status(
+    alert: MLAlert,
+    new_status: str,
+    request,
+    *,
+    resolution: str = "",
+) -> None:
+    alert.status = new_status
+    alert.acknowledged_at = timezone.now()
+    alert.acknowledged_by = request.user
+    if resolution:
+        alert.resolution = resolution
+    alert.save(
+        update_fields=["status", "acknowledged_at", "acknowledged_by", "resolution"]
+    )
+
+
+@login_required
+@user_passes_test(_is_staff_or_superuser)
+@require_POST
+def ack_alert(request, alert_id: int):
+    """Acknowledge an OPEN alert — operator has seen it but it's not yet
+    resolved. Idempotent for already-ACKNOWLEDGED alerts."""
+    alert = get_object_or_404(MLAlert, pk=alert_id)
+    if alert.status == "OPEN":
+        _set_status(alert, "ACKNOWLEDGED", request)
+        messages.success(request, f"Acknowledged alert #{alert.pk}.")
+    else:
+        messages.info(
+            request, f"Alert #{alert.pk} is already {alert.get_status_display()}."
+        )
+    return _redirect_back(request)
+
+
+@login_required
+@user_passes_test(_is_staff_or_superuser)
+@require_POST
+def dismiss_alert(request, alert_id: int):
+    """Resolve an alert — operator confirms it's been handled. Captures
+    optional `resolution` text from the form for audit."""
+    alert = get_object_or_404(MLAlert, pk=alert_id)
+    if alert.is_terminal:
+        messages.info(request, f"Alert #{alert.pk} already terminal.")
+        return _redirect_back(request)
+    resolution = (request.POST.get("resolution") or "").strip()
+    _set_status(alert, "RESOLVED", request, resolution=resolution)
+    messages.success(request, f"Resolved alert #{alert.pk}.")
+    return _redirect_back(request)
+
+
+@login_required
+@user_passes_test(_is_staff_or_superuser)
+@require_POST
+def mark_false_positive(request, alert_id: int):
+    """Mark an alert as a false positive. Feeds the rolling FPR widget
+    (PR 5) so the issue #5 <5% success metric is measurable."""
+    alert = get_object_or_404(MLAlert, pk=alert_id)
+    if alert.is_terminal:
+        messages.info(request, f"Alert #{alert.pk} already terminal.")
+        return _redirect_back(request)
+    resolution = (request.POST.get("resolution") or "").strip()
+    _set_status(alert, "FALSE_POSITIVE", request, resolution=resolution)
+    messages.success(request, f"Marked alert #{alert.pk} as false positive.")
+    return _redirect_back(request)
+
+
+@login_required
+@user_passes_test(_is_staff_or_superuser)
+@require_POST
+def rollback_model(request, model_id: int):
+    """Roll a model back to its previous DEPRECATED version. Guards in
+    `analyzer.ml.monitoring.rollback.perform_rollback` enforce: target
+    must be ACTIVE, prior must exist, no other rollback in last 24 h."""
+    target = get_object_or_404(MLModel, pk=model_id)
+    try:
+        audit = perform_rollback(target, performed_by=request.user)
+    except RollbackError as exc:
+        logger.warning("Rollback refused for model id=%s: %s", model_id, exc)
+        messages.error(request, str(exc))
+        return _redirect_back(request)
+
+    messages.success(
+        request,
+        f"Rolled back {target.name} v{target.version}. Audit alert #{audit.pk} created.",
+    )
+    return _redirect_back(request)


### PR DESCRIPTION
PR 4 of the issue-#5 stack. Triage actions for MLAlert rows plus a guarded manual rollback path. PR 5 adds the dashboard panel that calls these endpoints — they're wired in now so PR 5 is purely template/list work.

## Endpoints (all staff-only, POST-only)

| Path | Effect |
|---|---|
| \`POST /ml/alerts/<id>/ack/\` | \`OPEN → ACKNOWLEDGED\` |
| \`POST /ml/alerts/<id>/dismiss/\` | non-terminal → \`RESOLVED\` (+ optional \`resolution\` text) |
| \`POST /ml/alerts/<id>/false-positive/\` | non-terminal → \`FALSE_POSITIVE\` (+ optional \`resolution\`) |
| \`POST /ml/models/<id>/rollback/\` | guarded swap to prior DEPRECATED version |

## Rollback guards

In \`analyzer/ml/monitoring/rollback.py:perform_rollback\`:

1. Target must be \`ACTIVE\`
2. A prior DEPRECATED model of the same type must exist
3. No other rollback for the same model_type in the last 24 h (prevents thrash if the prior model is also bad)

On success: atomic swap (target → DEPRECATED, prior → ACTIVE) and a \`ROLLBACK_PERFORMED\` MLAlert row is created for audit, including the operator's User in \`acknowledged_by\` + a structured payload with both model identities.

\`can_rollback(model)\` exposed for the dashboard (PR 5) to decide whether to render the rollback button.

## Test plan

- [x] \`python manage.py test analyzer\` → **687 tests, 0 fail / 0 error / 14 skipped** (+18 new view+rollback tests)
- [x] \`black --check\` on all touched files
- [x] Coverage: anonymous → /login/ redirect; non-staff blocked; GET → 405; happy paths; idempotency for terminal states; rollback happy path + status swap + audit; rollback refusal (non-ACTIVE / no prior / cool-down); cool-down expiry after 24 h; \`can_rollback\` helper