### PR TITLE
feat(ml): alerts dashboard panel + rolling-7d FPR widget (issue #5, PR 5/5)

### DIFF
--- a/analyzer/templates/analyzer/ml_alerts.html
+++ b/analyzer/templates/analyzer/ml_alerts.html
@@ -1,0 +1,181 @@
+{% extends 'analyzer/base.html' %}
+{% load static %}
+
+{% block title %}ML alerts · QueryGrade{% endblock %}
+
+{% block content %}
+<div class="space-y-6">
+
+  <header class="flex flex-wrap items-center justify-between gap-3">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-white">🚨 ML alerts</h1>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        Drift, performance, and confidence triggers from the periodic monitoring task.
+        <a href="{% url 'ml_dashboard' %}" class="text-indigo-600 dark:text-indigo-400 hover:underline">← Back to dashboard</a>
+      </p>
+    </div>
+    <div class="text-right">
+      <div class="text-3xl font-bold text-red-600 dark:text-red-400">{{ open_count }}</div>
+      <div class="text-xs uppercase tracking-wide text-gray-500">Open</div>
+    </div>
+  </header>
+
+  {% if messages %}
+    {% for message in messages %}
+      <div class="rounded-md p-3 text-sm
+        {% if message.tags == 'success' %}bg-emerald-50 dark:bg-emerald-900/20 text-emerald-800 dark:text-emerald-200 border border-emerald-200 dark:border-emerald-800
+        {% elif message.tags == 'error' %}bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200 border border-red-200 dark:border-red-800
+        {% else %}bg-blue-50 dark:bg-blue-900/20 text-blue-800 dark:text-blue-200 border border-blue-200 dark:border-blue-800{% endif %}">
+        {{ message }}
+      </div>
+    {% endfor %}
+  {% endif %}
+
+  <section class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+    <div class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
+      <div class="text-xs uppercase tracking-wide text-gray-500">False-positive rate (rolling {{ fpr.window_days }}d)</div>
+      <div class="mt-2 text-3xl font-bold
+        {% if fpr.fpr_pct is None %}text-gray-400
+        {% elif fpr.fpr_pct <= 5 %}text-emerald-600 dark:text-emerald-400
+        {% elif fpr.fpr_pct <= 15 %}text-amber-600 dark:text-amber-400
+        {% else %}text-red-600 dark:text-red-400{% endif %}">
+        {% if fpr.fpr_pct is None %}—{% else %}{{ fpr.fpr_pct|floatformat:1 }}%{% endif %}
+      </div>
+      <div class="text-xs text-gray-500 mt-1">
+        {{ fpr.fp_count }} false positive · {{ fpr.resolved_count }} resolved
+        {% if fpr.fpr_pct is not None %}· target &lt;5%{% endif %}
+      </div>
+    </div>
+
+    <div class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
+      <div class="text-xs uppercase tracking-wide text-gray-500">Active models</div>
+      <div class="mt-2 text-3xl font-bold text-gray-900 dark:text-white">{{ active_models|length }}</div>
+      <div class="text-xs text-gray-500 mt-1">
+        {% for m in active_models %}{{ m.name }} v{{ m.version }}{% if not forloop.last %}, {% endif %}{% endfor %}
+      </div>
+    </div>
+
+    <div class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-5">
+      <div class="text-xs uppercase tracking-wide text-gray-500">Monitoring schedule</div>
+      <div class="mt-2 text-3xl font-bold text-gray-900 dark:text-white">15 min</div>
+      <div class="text-xs text-gray-500 mt-1">Celery Beat → <code>analyzer.tasks.monitor_ml_models</code></div>
+    </div>
+  </section>
+
+  <form method="get" class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] p-4 flex flex-wrap gap-3 items-end">
+    <div>
+      <label class="block text-xs font-medium text-gray-700 dark:text-gray-300">Status</label>
+      <input type="text" name="status" value="{{ current_status }}" placeholder="OPEN,ACKNOWLEDGED" class="mt-1 px-2 py-1 border border-gray-300 dark:border-[#1f1f23] rounded bg-white dark:bg-[#0a0a0a] text-sm">
+    </div>
+    <div>
+      <label class="block text-xs font-medium text-gray-700 dark:text-gray-300">Severity</label>
+      <input type="text" name="severity" value="{{ current_severity }}" placeholder="CRITICAL,HIGH" class="mt-1 px-2 py-1 border border-gray-300 dark:border-[#1f1f23] rounded bg-white dark:bg-[#0a0a0a] text-sm">
+    </div>
+    <div>
+      <label class="block text-xs font-medium text-gray-700 dark:text-gray-300">Model</label>
+      <select name="model" class="mt-1 px-2 py-1 border border-gray-300 dark:border-[#1f1f23] rounded bg-white dark:bg-[#0a0a0a] text-sm">
+        <option value="">All</option>
+        {% for m in active_models %}
+          <option value="{{ m.id }}" {% if current_model == m.id|stringformat:"s" %}selected{% endif %}>{{ m.name }} v{{ m.version }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <button type="submit" class="px-3 py-1.5 bg-indigo-600 text-white text-sm rounded hover:bg-indigo-700">Filter</button>
+    <a href="{% url 'ml_alerts' %}" class="px-3 py-1.5 text-sm text-gray-600 dark:text-gray-300 hover:underline">Clear</a>
+  </form>
+
+  <section class="bg-white dark:bg-[#111113] rounded-lg border border-gray-200 dark:border-[#1f1f23] overflow-hidden">
+    {% if alerts %}
+    <table class="w-full text-sm">
+      <thead class="bg-gray-50 dark:bg-[#17181c] text-gray-600 dark:text-gray-400 text-xs uppercase tracking-wide">
+        <tr>
+          <th class="text-left px-4 py-2">When</th>
+          <th class="text-left px-4 py-2">Severity</th>
+          <th class="text-left px-4 py-2">Type</th>
+          <th class="text-left px-4 py-2">Model</th>
+          <th class="text-left px-4 py-2">Status</th>
+          <th class="text-left px-4 py-2">Message</th>
+          <th class="text-right px-4 py-2">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for alert in alerts %}
+        <tr class="border-t border-gray-100 dark:border-[#1f1f23]
+          {% if alert.severity == 'CRITICAL' and alert.is_open %}bg-red-50 dark:bg-red-900/10{% endif %}">
+          <td class="px-4 py-2 text-gray-700 dark:text-gray-300 text-xs">{{ alert.created_at|date:"Y-m-d H:i" }}</td>
+          <td class="px-4 py-2">
+            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium
+              {% if alert.severity == 'CRITICAL' %}bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200
+              {% elif alert.severity == 'HIGH' %}bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200
+              {% elif alert.severity == 'MEDIUM' %}bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200
+              {% else %}bg-gray-100 dark:bg-gray-800/40 text-gray-700 dark:text-gray-300{% endif %}">
+              {{ alert.get_severity_display }}
+            </span>
+          </td>
+          <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ alert.get_alert_type_display }}</td>
+          <td class="px-4 py-2 text-gray-700 dark:text-gray-300 text-xs">{{ alert.model.name }} v{{ alert.model.version }}</td>
+          <td class="px-4 py-2 text-xs">
+            <span class="px-2 py-0.5 rounded
+              {% if alert.status == 'OPEN' %}bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200
+              {% elif alert.status == 'ACKNOWLEDGED' %}bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200
+              {% elif alert.status == 'RESOLVED' %}bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200
+              {% else %}bg-gray-100 dark:bg-gray-800/40 text-gray-700 dark:text-gray-300{% endif %}">
+              {{ alert.get_status_display }}
+            </span>
+          </td>
+          <td class="px-4 py-2 text-gray-700 dark:text-gray-300 text-xs">{{ alert.message|truncatechars:80 }}</td>
+          <td class="px-4 py-2 text-right whitespace-nowrap">
+            {% if alert.status == 'OPEN' %}
+              <form method="post" action="{% url 'ml_alert_ack' alert.id %}" class="inline">
+                {% csrf_token %}
+                <button class="text-xs px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700">Ack</button>
+              </form>
+            {% endif %}
+            {% if not alert.is_terminal %}
+              <form method="post" action="{% url 'ml_alert_dismiss' alert.id %}" class="inline">
+                {% csrf_token %}
+                <button class="text-xs px-2 py-1 bg-emerald-600 text-white rounded hover:bg-emerald-700">Resolve</button>
+              </form>
+              <form method="post" action="{% url 'ml_alert_false_positive' alert.id %}" class="inline">
+                {% csrf_token %}
+                <button class="text-xs px-2 py-1 bg-gray-500 text-white rounded hover:bg-gray-600" title="Mark as false positive — feeds the FPR widget">FP</button>
+              </form>
+            {% endif %}
+            {% if alert.model_can_rollback %}
+              <form method="post" action="{% url 'ml_model_rollback' alert.model.id %}" class="inline" onsubmit="return confirm('Roll back {{ alert.model.name }} v{{ alert.model.version }} to its prior version? This is reversible only via re-deployment.');">
+                {% csrf_token %}
+                <button class="text-xs px-2 py-1 bg-red-600 text-white rounded hover:bg-red-700" title="Roll back to prior DEPRECATED version">Rollback</button>
+              </form>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    {% if page_obj.has_other_pages %}
+    <div class="px-4 py-3 border-t border-gray-100 dark:border-[#1f1f23] flex items-center justify-between text-sm">
+      <div class="text-gray-500">
+        Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }} · {{ page_obj.paginator.count }} alert{{ page_obj.paginator.count|pluralize }}
+      </div>
+      <div class="flex gap-2">
+        {% if page_obj.has_previous %}
+          <a class="px-2 py-1 border border-gray-300 dark:border-[#1f1f23] rounded text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-[#17181c]" href="?{% if current_status %}status={{ current_status }}&{% endif %}{% if current_severity %}severity={{ current_severity }}&{% endif %}{% if current_model %}model={{ current_model }}&{% endif %}page={{ page_obj.previous_page_number }}">← Prev</a>
+        {% endif %}
+        {% if page_obj.has_next %}
+          <a class="px-2 py-1 border border-gray-300 dark:border-[#1f1f23] rounded text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-[#17181c]" href="?{% if current_status %}status={{ current_status }}&{% endif %}{% if current_severity %}severity={{ current_severity }}&{% endif %}{% if current_model %}model={{ current_model }}&{% endif %}page={{ page_obj.next_page_number }}">Next →</a>
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
+
+    {% else %}
+    <div class="p-8 text-center text-gray-500">
+      <p class="text-2xl">✓</p>
+      <p class="mt-2 text-sm">No alerts match these filters.</p>
+    </div>
+    {% endif %}
+  </section>
+
+</div>
+{% endblock %}

--- a/analyzer/templates/analyzer/ml_dashboard.html
+++ b/analyzer/templates/analyzer/ml_dashboard.html
@@ -10,7 +10,13 @@
       <h1 class="text-2xl font-bold text-gray-900">📈 ML performance dashboard</h1>
       <p class="mt-1 text-sm text-gray-500">Real-time monitoring of ML system performance and user satisfaction.</p>
     </div>
-    <div class="text-xs text-gray-500">Last updated: <span id="last-update">—</span></div>
+    <div class="flex items-center gap-3">
+      <a href="{% url 'ml_alerts' %}" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded border border-gray-300 dark:border-[#1f1f23] text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-[#17181c]">
+        <span>🚨</span>
+        <span>Alerts</span>
+      </a>
+      <div class="text-xs text-gray-500">Last updated: <span id="last-update">—</span></div>
+    </div>
   </header>
 
   <section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/analyzer/test_ml_alerts_list.py
+++ b/analyzer/test_ml_alerts_list.py
@@ -1,0 +1,246 @@
+"""
+Tests for the /ml/alerts/ dashboard panel + FPR widget (issue #5, PR 5).
+"""
+
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from analyzer.models import MLAlert, MLModel
+
+
+class FPRComputationTests(TestCase):
+    """Direct exercise of _compute_fpr()."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.model = MLModel.objects.create(
+            name="HybridScorer",
+            model_type="HYBRID_SCORER",
+            version="1.0.0",
+            status="ACTIVE",
+            file_path="/tmp/dummy.joblib",
+            checksum="0" * 64,
+        )
+
+    def _alert(self, status="OPEN", days_ago=0):
+        a = MLAlert.objects.create(
+            model=self.model,
+            alert_type="PERFORMANCE",
+            severity="HIGH",
+            status=status,
+            message="test",
+        )
+        if days_ago > 0:
+            MLAlert.objects.filter(pk=a.pk).update(
+                created_at=timezone.now() - timedelta(days=days_ago)
+            )
+        return a
+
+    def test_empty_dataset_returns_none_pct(self):
+        from analyzer.views.ml_alert_views import _compute_fpr
+
+        result = _compute_fpr()
+        self.assertIsNone(result["fpr_pct"])
+        self.assertEqual(result["fp_count"], 0)
+        self.assertEqual(result["resolved_count"], 0)
+        self.assertEqual(result["window_days"], 7)
+
+    def test_only_resolved_returns_zero_pct(self):
+        from analyzer.views.ml_alert_views import _compute_fpr
+
+        self._alert(status="RESOLVED")
+        self._alert(status="RESOLVED")
+        result = _compute_fpr()
+        self.assertEqual(result["fpr_pct"], 0.0)
+        self.assertEqual(result["resolved_count"], 2)
+
+    def test_mixed_yields_correct_pct(self):
+        from analyzer.views.ml_alert_views import _compute_fpr
+
+        # 1 FP + 9 RESOLVED → 10% FPR
+        self._alert(status="FALSE_POSITIVE")
+        for _ in range(9):
+            self._alert(status="RESOLVED")
+        result = _compute_fpr()
+        self.assertEqual(result["fp_count"], 1)
+        self.assertEqual(result["resolved_count"], 9)
+        self.assertEqual(result["total_terminal"], 10)
+        self.assertAlmostEqual(result["fpr_pct"], 10.0)
+
+    def test_open_alerts_excluded(self):
+        from analyzer.views.ml_alert_views import _compute_fpr
+
+        self._alert(status="OPEN")
+        self._alert(status="ACKNOWLEDGED")
+        self._alert(status="FALSE_POSITIVE")
+        self._alert(status="RESOLVED")
+        result = _compute_fpr()
+        # Only FALSE_POSITIVE + RESOLVED counted
+        self.assertEqual(result["total_terminal"], 2)
+        self.assertEqual(result["fpr_pct"], 50.0)
+
+    def test_outside_window_excluded(self):
+        from analyzer.views.ml_alert_views import _compute_fpr
+
+        self._alert(status="FALSE_POSITIVE", days_ago=10)  # outside 7d
+        self._alert(status="RESOLVED")  # in window
+        result = _compute_fpr()
+        self.assertEqual(result["fp_count"], 0)
+        self.assertEqual(result["resolved_count"], 1)
+        self.assertEqual(result["fpr_pct"], 0.0)
+
+
+class AlertsListViewTests(TestCase):
+    """The /ml/alerts/ GET endpoint."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            username="ops", password="opspass123", is_staff=True
+        )
+        cls.regular = User.objects.create_user(
+            username="rando", password="randopass123"
+        )
+        cls.model_a = MLModel.objects.create(
+            name="HybridScorer",
+            model_type="HYBRID_SCORER",
+            version="2.0.0",
+            status="ACTIVE",
+            file_path="/tmp/a.joblib",
+            checksum="0" * 64,
+        )
+        cls.model_b = MLModel.objects.create(
+            name="FeatureExtractor",
+            model_type="FEATURE_EXTRACTOR",
+            version="1.0.0",
+            status="ACTIVE",
+            file_path="/tmp/b.joblib",
+            checksum="1" * 64,
+        )
+
+    def setUp(self):
+        self.client = Client()
+        # Seed a representative mix of alerts
+        self.open_critical = MLAlert.objects.create(
+            model=self.model_a,
+            alert_type="PERFORMANCE",
+            severity="CRITICAL",
+            status="OPEN",
+            message="Accuracy collapsed.",
+        )
+        self.open_high = MLAlert.objects.create(
+            model=self.model_b,
+            alert_type="DATA_DRIFT",
+            severity="HIGH",
+            status="OPEN",
+            message="KS-stat spiked.",
+        )
+        self.ack = MLAlert.objects.create(
+            model=self.model_a,
+            alert_type="CONFIDENCE",
+            severity="MEDIUM",
+            status="ACKNOWLEDGED",
+            message="Confidence low.",
+        )
+        self.resolved = MLAlert.objects.create(
+            model=self.model_a,
+            alert_type="TIME_BASED",
+            severity="LOW",
+            status="RESOLVED",
+            message="Routine retrain hit.",
+        )
+        self.fp = MLAlert.objects.create(
+            model=self.model_b,
+            alert_type="DATA_DRIFT",
+            severity="LOW",
+            status="FALSE_POSITIVE",
+            message="Detector noise.",
+        )
+
+    def test_requires_login(self):
+        response = self.client.get(reverse("ml_alerts"))
+        self.assertEqual(response.status_code, 302)
+
+    def test_requires_staff(self):
+        self.client.login(username="rando", password="randopass123")
+        response = self.client.get(reverse("ml_alerts"))
+        self.assertEqual(response.status_code, 302)  # to LOGIN_URL
+
+    def test_renders_for_staff(self):
+        self.client.login(username="ops", password="opspass123")
+        response = self.client.get(reverse("ml_alerts"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "ML alerts")
+        # FPR widget rendered (1 FP + 1 RESOLVED → 50%)
+        self.assertContains(response, "50.0%")
+
+    def test_default_filter_shows_open_and_acked(self):
+        self.client.login(username="ops", password="opspass123")
+        response = self.client.get(reverse("ml_alerts"))
+        self.assertContains(response, "Accuracy collapsed.")
+        self.assertContains(response, "KS-stat spiked.")
+        self.assertContains(response, "Confidence low.")
+        # Resolved + FP not in default view
+        self.assertNotContains(response, "Routine retrain hit.")
+        self.assertNotContains(response, "Detector noise.")
+
+    def test_all_filter_shows_terminal_too(self):
+        self.client.login(username="ops", password="opspass123")
+        response = self.client.get(reverse("ml_alerts") + "?status=all")
+        self.assertContains(response, "Routine retrain hit.")
+        self.assertContains(response, "Detector noise.")
+
+    def test_severity_filter(self):
+        self.client.login(username="ops", password="opspass123")
+        response = self.client.get(reverse("ml_alerts") + "?severity=CRITICAL")
+        self.assertContains(response, "Accuracy collapsed.")
+        self.assertNotContains(response, "KS-stat spiked.")
+
+    def test_model_filter(self):
+        self.client.login(username="ops", password="opspass123")
+        response = self.client.get(reverse("ml_alerts") + f"?model={self.model_b.id}")
+        self.assertContains(response, "KS-stat spiked.")
+        self.assertNotContains(response, "Accuracy collapsed.")
+
+    def test_open_count_in_header(self):
+        self.client.login(username="ops", password="opspass123")
+        response = self.client.get(reverse("ml_alerts"))
+        # 2 OPEN seeded
+        self.assertContains(response, "2")
+        self.assertContains(response, "Open")
+
+    def test_action_buttons_render_for_open_alerts(self):
+        self.client.login(username="ops", password="opspass123")
+        response = self.client.get(reverse("ml_alerts"))
+        # Ack/Resolve/FP buttons for OPEN
+        self.assertContains(response, "Ack")
+        self.assertContains(response, "Resolve")
+        # POST URLs present
+        self.assertContains(
+            response, reverse("ml_alert_ack", args=[self.open_critical.id])
+        )
+        self.assertContains(
+            response, reverse("ml_alert_dismiss", args=[self.open_critical.id])
+        )
+        self.assertContains(
+            response, reverse("ml_alert_false_positive", args=[self.open_critical.id])
+        )
+
+    def test_pagination_kicks_in_above_25(self):
+        # Create 30 more open alerts to push past page size 25
+        for i in range(30):
+            MLAlert.objects.create(
+                model=self.model_a,
+                alert_type="PERFORMANCE",
+                severity="LOW",
+                status="OPEN",
+                message=f"bulk-{i}",
+            )
+        self.client.login(username="ops", password="opspass123")
+        response = self.client.get(reverse("ml_alerts"))
+        self.assertContains(response, "Page 1 of")
+        self.assertContains(response, "Next →")

--- a/analyzer/urls.py
+++ b/analyzer/urls.py
@@ -141,7 +141,8 @@ urlpatterns = [
         dashboard_views.dashboard_api_trigger_training,
         name="ml_api_trigger_training",
     ),
-    # ML alert triage (issue #5). List view ships in PR 5 of the stack.
+    # ML alert triage (issue #5).
+    path("ml/alerts/", ml_alert_views.ml_alerts_list, name="ml_alerts"),
     path(
         "ml/alerts/<int:alert_id>/ack/",
         ml_alert_views.ack_alert,

--- a/analyzer/views/ml_alert_views.py
+++ b/analyzer/views/ml_alert_views.py
@@ -1,27 +1,61 @@
 """
 Views for ML alert triage and manual rollback (issue #5).
 
-POST-only mutating endpoints, staff-only. The list view (GET /ml/alerts/)
-ships in PR 5 — this PR adds the action endpoints so the dashboard panel
-in PR 5 has working buttons from day one.
+POST-only mutating endpoints, staff-only. GET /ml/alerts/ renders the
+triage list with filters + rolling FPR widget.
 """
 
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
+from django.core.paginator import Paginator
+from django.db.models import Count, Q
 from django.http import HttpResponseRedirect
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_POST
 
+from analyzer.ml.monitoring.rollback import can_rollback
 from analyzer.ml.monitoring.rollback import RollbackError, perform_rollback
 from analyzer.models import MLAlert, MLModel
 
 logger = logging.getLogger(__name__)
+
+
+FPR_WINDOW = timedelta(days=7)
+
+
+def _compute_fpr(window: timedelta = FPR_WINDOW) -> dict:
+    """Rolling false-positive rate across the resolved population.
+
+    Returns {fpr_pct, fp_count, resolved_count, total_terminal, window_days}.
+    `fpr_pct` is None when the resolved population is empty (avoid divide by
+    zero and avoid implying a meaningful rate from no data).
+    """
+    cutoff = timezone.now() - window
+    counts = MLAlert.objects.filter(
+        created_at__gte=cutoff,
+        status__in=("RESOLVED", "FALSE_POSITIVE"),
+    ).aggregate(
+        fp=Count("id", filter=Q(status="FALSE_POSITIVE")),
+        resolved=Count("id", filter=Q(status="RESOLVED")),
+    )
+    fp = counts["fp"] or 0
+    resolved = counts["resolved"] or 0
+    total = fp + resolved
+    fpr_pct = (100.0 * fp / total) if total else None
+    return {
+        "fpr_pct": fpr_pct,
+        "fp_count": fp,
+        "resolved_count": resolved,
+        "total_terminal": total,
+        "window_days": window.days,
+    }
 
 
 def _is_staff_or_superuser(user) -> bool:
@@ -126,3 +160,64 @@ def rollback_model(request, model_id: int):
         f"Rolled back {target.name} v{target.version}. Audit alert #{audit.pk} created.",
     )
     return _redirect_back(request)
+
+
+@login_required
+@user_passes_test(_is_staff_or_superuser)
+def ml_alerts_list(request):
+    """Paginated triage list with severity/status filters + FPR widget.
+
+    Query params:
+      - status: comma-separated filter (default: OPEN,ACKNOWLEDGED)
+      - severity: comma-separated filter (default: all)
+      - model: model id filter
+      - page: pagination cursor
+    """
+    qs = MLAlert.objects.select_related("model", "acknowledged_by")
+
+    raw_status = request.GET.get("status", "OPEN,ACKNOWLEDGED")
+    status_filter = [s for s in (s.strip() for s in raw_status.split(",")) if s]
+    if status_filter and "all" not in status_filter:
+        qs = qs.filter(status__in=status_filter)
+
+    raw_severity = request.GET.get("severity", "")
+    severity_filter = [s for s in (s.strip() for s in raw_severity.split(",")) if s]
+    if severity_filter:
+        qs = qs.filter(severity__in=severity_filter)
+
+    model_filter = request.GET.get("model")
+    if model_filter:
+        try:
+            qs = qs.filter(model_id=int(model_filter))
+        except (TypeError, ValueError):
+            pass
+
+    paginator = Paginator(qs, 25)
+    page_obj = paginator.get_page(request.GET.get("page"))
+
+    # Decorate each alert with whether the underlying model is rollback-eligible
+    # (the dashboard renders a rollback button per row only when this is True).
+    page_alerts = list(page_obj.object_list)
+    seen_models = {}
+    for alert in page_alerts:
+        model = alert.model
+        if model.pk not in seen_models:
+            seen_models[model.pk] = can_rollback(model)
+        alert.model_can_rollback = seen_models[model.pk]
+
+    open_count = MLAlert.objects.filter(status="OPEN").count()
+    active_models = MLModel.objects.filter(status="ACTIVE")
+
+    context = {
+        "page_obj": page_obj,
+        "alerts": page_alerts,
+        "open_count": open_count,
+        "fpr": _compute_fpr(),
+        "active_models": active_models,
+        "status_choices": MLAlert.STATUS_CHOICES,
+        "severity_choices": MLAlert.SEVERITY_CHOICES,
+        "current_status": raw_status,
+        "current_severity": raw_severity,
+        "current_model": model_filter or "",
+    }
+    return render(request, "analyzer/ml_alerts.html", context)


### PR DESCRIPTION
**Final PR of the issue-#5 stack.** Adds the operator-facing alerts panel that surfaces what the prior 4 PRs produce: a paginated triage view of MLAlert rows with ack/dismiss/false-positive buttons, a rolling-7d false-positive rate widget (the third issue #5 success metric), and a guarded per-row rollback button.

## Components

- **\`analyzer/views/ml_alert_views.py:ml_alerts_list\`** — paginated GET view at \`/ml/alerts/\` with status/severity/model filters. Defaults to \`status=OPEN,ACKNOWLEDGED\` so the panel shows actionable work first. \`?status=all\` includes terminal alerts for retrospect.

- **\`_compute_fpr()\`** — rolling 7-day \`FALSE_POSITIVE / (RESOLVED + FALSE_POSITIVE)\`. Returns \`None\` when the resolved population is empty (avoid implying a meaningful rate from no data).

- **\`analyzer/templates/analyzer/ml_alerts.html\`** — Tailwind triage table. Severity-tinted rows for CRITICAL+OPEN. FPR widget color-codes by issue #5 threshold (≤5% green, ≤15% amber, otherwise red). Rollback button renders only when \`can_rollback(model)\` returns True (target ACTIVE, prior DEPRECATED exists, no recent rollback). \`onsubmit=\"return confirm(...)\"\` guards the rollback POST.

- **\`ml_dashboard.html\`** — adds an "🚨 Alerts" link in the header. Dashboard remains the canonical entry point.

## Test plan

- [x] \`python manage.py test analyzer\` → **702 tests, 0 fail / 0 error / 14 skipped** (+15 new)
- [x] \`black --check\` on all touched files
- [x] Coverage: \`_compute_fpr\` (empty, only-resolved, mixed, OPEN excluded, outside-window excluded); list view auth (anonymous, non-staff, staff); default filter; \`?status=all\`; severity filter; model filter; open-count; action button URLs; pagination

## Issue #5 stack summary

| PR | Title | Tests | Status |
|---|---|---|---|
| #71 | MLAlert model + admin | +9 | ✓ merged |
| #73 | monitor_models command + Celery Beat | +12 | ✓ merged |
| #74 | Email delivery + 4h throttle | +11 | ✓ merged |
| #75 | Ack/FP views + safety-guarded rollback | +18 | ✓ merged |
| (this) | Dashboard panel + rolling-7d FPR widget | +15 | ready |

**Success metrics:**
- ✓ Drift detection within 24h — Beat fires every 15 min
- ✓ Alert response <5 min — email sent sync after \`MLAlert.save()\`
- ✓ FPR <5% — now *measurable* via this PR's widget; capture started in #75

**Out of scope (future):**
- Auto-rollback (graduates after FPR proven <5% over 30 days)
- Slack/PagerDuty integrations (email-only in v1)
- Prometheus/Sentry export of LearningMetrics