### PR TITLE
chore(lint): weekly black/isort/flake8 sweep

### DIFF
--- a/analyzer/ml/tests/test_alert_notifier.py
+++ b/analyzer/ml/tests/test_alert_notifier.py
@@ -189,13 +189,14 @@ class EvaluatorEmailIntegrationTests(TestCase):
         cache.clear()
 
     def test_evaluation_sends_one_email_per_new_alert(self):
+        from django.utils import timezone as dj_timezone
+
         from analyzer.ml.monitoring import alert_evaluator
         from analyzer.ml.monitoring.retraining_system import (
             RetrainingTrigger,
             TriggerReason,
             TriggerUrgency,
         )
-        from django.utils import timezone as dj_timezone
 
         triggers = [
             RetrainingTrigger(

--- a/analyzer/urls.py
+++ b/analyzer/urls.py
@@ -9,7 +9,6 @@ from django.urls import path
 
 # ML Dashboard views (separate module)
 from .ml import dashboard_views
-from .views import ml_alert_views
 
 # Import from modular views package
 from .views import (  # Authentication views; Query grading views; Comparison views; Batch analysis views; History and feedback views; Upload views; Database introspection views; Async processing views; API views; Saved connection views
@@ -39,6 +38,7 @@ from .views import (  # Authentication views; Query grading views; Comparison vi
     index,
     login_view,
     logout_view,
+    ml_alert_views,
     password_change,
     password_reset_confirm,
     password_reset_request,

--- a/analyzer/views/ml_alert_views.py
+++ b/analyzer/views/ml_alert_views.py
@@ -20,8 +20,11 @@ from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_POST
 
-from analyzer.ml.monitoring.rollback import can_rollback
-from analyzer.ml.monitoring.rollback import RollbackError, perform_rollback
+from analyzer.ml.monitoring.rollback import (
+    RollbackError,
+    can_rollback,
+    perform_rollback,
+)
 from analyzer.models import MLAlert, MLModel
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

- isort reformatted 3 files: `analyzer/urls.py`, `analyzer/views/ml_alert_views.py`, `analyzer/ml/tests/test_alert_notifier.py`
- black: no changes (207 files already clean)
- 3 files changed, 8 insertions(+), 4 deletions(-)

### Outstanding flake8 findings (manual fix required)

1182 findings total — all require manual intervention. Breakdown by code:

| Code | Count | Description |
|------|-------|-------------|
| E501 | 744   | Line too long (> 88 chars) |
| F401 | 332   | Imported but unused |
| F841 | 51    | Local variable assigned but never used |
| F541 | 19    | f-string without placeholders |
| F405 | 14    | May be undefined from star import |
| E402 | 8     | Module level import not at top of file |
| F811 | 7     | Redefinition of unused name |
| F403 | 5     | Unable to detect undefined names from star import |
| F821 | 2     | Undefined name |

Top files with issues: `analyzer/admin/__init__.py`, `analyzer/analyzers/base.py`, `analyzer/analyzers/case_statement_analyzer.py`, `analyzer/admin/ml_admin.py`, `analyzer/analyzers/database/`.

Use `flake8 analyzer/ querygrade/` locally for the full list.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJqqQSZWdCRdkxS48ugowT)_