### PR TITLE
chore(lint): weekly black/isort/flake8 sweep

### DIFF
--- a/analyzer/ml/tests/test_alert_notifier.py
+++ b/analyzer/ml/tests/test_alert_notifier.py
@@ -189,13 +189,14 @@ class EvaluatorEmailIntegrationTests(TestCase):
         cache.clear()
 
     def test_evaluation_sends_one_email_per_new_alert(self):
+        from django.utils import timezone as dj_timezone
+
         from analyzer.ml.monitoring import alert_evaluator
         from analyzer.ml.monitoring.retraining_system import (
             RetrainingTrigger,
             TriggerReason,
             TriggerUrgency,
         )
-        from django.utils import timezone as dj_timezone
 
         triggers = [
             RetrainingTrigger(

--- a/analyzer/urls.py
+++ b/analyzer/urls.py
@@ -9,7 +9,6 @@ from django.urls import path
 
 # ML Dashboard views (separate module)
 from .ml import dashboard_views
-from .views import ml_alert_views
 
 # Import from modular views package
 from .views import (  # Authentication views; Query grading views; Comparison views; Batch analysis views; History and feedback views; Upload views; Database introspection views; Async processing views; API views; Saved connection views
@@ -39,6 +38,7 @@ from .views import (  # Authentication views; Query grading views; Comparison vi
     index,
     login_view,
     logout_view,
+    ml_alert_views,
     password_change,
     password_reset_confirm,
     password_reset_request,

--- a/analyzer/views/ml_alert_views.py
+++ b/analyzer/views/ml_alert_views.py
@@ -20,8 +20,11 @@ from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_POST
 
-from analyzer.ml.monitoring.rollback import can_rollback
-from analyzer.ml.monitoring.rollback import RollbackError, perform_rollback
+from analyzer.ml.monitoring.rollback import (
+    RollbackError,
+    can_rollback,
+    perform_rollback,
+)
 from analyzer.models import MLAlert, MLModel
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

- **black**: no changes (207 files already formatted)
- **isort**: fixed import ordering in 3 files
- **flake8**: 1,182 findings (manual fix required — see below)

**Files changed:** 3 files changed, 8 insertions(+), 4 deletions(-)

Files reformatted by isort:
- `analyzer/urls.py`
- `analyzer/views/ml_alert_views.py`
- `analyzer/ml/tests/test_alert_notifier.py`

---

### Outstanding flake8 findings (manual fix required)

1,182 total findings. Predominant error codes:
- **E501** — line too long (vast majority)
- **F401** — imported but unused
- **E402** — module level import not at top of file
- **F841** — local variable assigned but never used
- **W503/W504** — line break before/after binary operator

<details>
<summary>First 100 findings (click to expand)</summary>

```
analyzer/admin/__init__.py:7:89: E501 line too long (94 > 88 characters)
analyzer/admin/__init__.py:9:89: E501 line too long (92 > 88 characters)
analyzer/admin/__init__.py:16:1: F401 '.ml_admin' imported but unused
analyzer/admin/__init__.py:16:1: F401 '.query_admin' imported but unused
analyzer/admin/__init__.py:16:1: F401 '.user_admin' imported but unused
analyzer/admin/__init__.py:23:1: E402 module level import not at top of file
analyzer/admin/__init__.py:32:1: E402 module level import not at top of file
analyzer/admin/__init__.py:33:1: E402 module level import not at top of file
analyzer/admin/ml_admin.py:250:89: E501 line too long (141 > 88 characters)
analyzer/admin/ml_admin.py:251:89: E501 line too long (110 > 88 characters)
analyzer/admin/ml_admin.py:252:89: E501 line too long (138 > 88 characters)
analyzer/admin/ml_admin.py:327:89: E501 line too long (92 > 88 characters)
analyzer/admin/user_admin.py:39:89: E501 line too long (92 > 88 characters)
analyzer/analyzers/base.py:19:1: F401 'django.core.cache.caches' imported but unused
analyzer/analyzers/base.py:86:89: E501 line too long (89 > 88 characters)
analyzer/analyzers/base.py:158:9: F841 local variable 'start_time' is assigned to but never used
analyzer/analyzers/base.py:214:89: E501 line too long (91 > 88 characters)
analyzer/analyzers/base.py:215:89: E501 line too long (97 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:69:89: E501 line too long (118 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:76:89: E501 line too long (131 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:77:89: E501 line too long (154 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:89:89: E501 line too long (126 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:96:89: E501 line too long (111 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:97:89: E501 line too long (120 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:105:89: E501 line too long (150 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:116:89: E501 line too long (123 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:123:89: E501 line too long (92 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:124:89: E501 line too long (148 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:135:89: E501 line too long (98 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:142:89: E501 line too long (95 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:143:89: E501 line too long (150 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:159:89: E501 line too long (117 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:166:89: E501 line too long (122 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:167:89: E501 line too long (153 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:181:89: E501 line too long (111 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:182:89: E501 line too long (139 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:192:89: E501 line too long (100 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:193:89: E501 line too long (120 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:207:89: E501 line too long (103 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:215:89: E501 line too long (130 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:238:89: E501 line too long (123 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:239:89: E501 line too long (140 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:250:89: E501 line too long (110 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:264:89: E501 line too long (99 > 88 characters)
analyzer/analyzers/case_statement_analyzer.py:265:89: E501 line too long (95 > 88 characters)
analyzer/analyzers/database/mysql_analyzer.py:70:89: E501 line too long (118 > 88 characters)
analyzer/analyzers/database/mysql_analyzer.py:80:89: E501 line too long (97 > 88 characters)
analyzer/analyzers/database/mysql_analyzer.py:93:89: E501 line too long (103 > 88 characters)
analyzer/analyzers/database/mysql_analyzer.py:106:89: E501 line too long (134 > 88 characters)
analyzer/analyzers/database/postgresql_analyzer.py:52:89: E501 line too long (89 > 88 characters)
analyzer/analyzers/database/postgresql_analyzer.py:65:89: E501 line too long (114 > 88 characters)
analyzer/analyzers/database/postgresql_analyzer.py:78:89: E501 line too long (99 > 88 characters)
analyzer/analyzers/database/postgresql_analyzer.py:91:89: E501 line too long (108 > 88 characters)
analyzer/analyzers/database/postgresql_analyzer.py:104:89: E501 line too long (120 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:69:89: E501 line too long (97 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:86:89: E501 line too long (124 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:87:89: E501 line too long (102 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:113:89: E501 line too long (140 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:120:89: E501 line too long (126 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:121:89: E501 line too long (155 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:132:89: E501 line too long (90 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:139:89: E501 line too long (95 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:140:89: E501 line too long (106 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:160:89: E501 line too long (137 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:167:89: E501 line too long (129 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:168:89: E501 line too long (121 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:182:89: E501 line too long (91 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:193:89: E501 line too long (140 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:200:89: E501 line too long (126 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:201:89: E501 line too long (105 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:206:89: E501 line too long (99 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:216:89: E501 line too long (121 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:217:89: E501 line too long (108 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:231:89: E501 line too long (117 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:232:89: E501 line too long (101 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:245:89: E501 line too long (114 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:256:89: E501 line too long (94 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:257:89: E501 line too long (113 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:267:89: E501 line too long (114 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:274:89: E501 line too long (119 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:275:89: E501 line too long (127 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:288:89: E501 line too long (123 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:295:89: E501 line too long (104 > 88 characters)
analyzer/analyzers/groupby_analyzer.py:296:89: E501 line too long (104 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:58:89: E501 line too long (117 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:59:89: E501 line too long (93 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:69:89: E501 line too long (99 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:70:89: E501 line too long (92 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:80:89: E501 line too long (113 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:87:89: E501 line too long (121 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:88:89: E501 line too long (102 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:101:89: E501 line too long (115 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:102:89: E501 line too long (100 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:113:89: E501 line too long (130 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:114:89: E501 line too long (96 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:125:89: E501 line too long (107 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:126:89: E501 line too long (91 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:136:89: E501 line too long (111 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:137:89: E501 line too long (101 > 88 characters)
analyzer/analyzers/indexing_analyzer.py:147:89: E501 line too long (119 > 88 characters)
```

_(1,082 more findings not shown — full output available in CI or by running `flake8 analyzer/ querygrade/` locally)_

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcqm1hWfS7SkLsSquJWFxY)_