### PR TITLE
fix(worker): pin Celery concurrency to 2 (#126)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -20,4 +20,8 @@ RUN pip install -r requirements-worker.txt
 
 COPY . .
 
-CMD ["celery", "-A", "querygrade", "worker", "--loglevel=info"]
+# --concurrency pinned so a container run matches prod. Without it Celery's
+# prefork pool defaults to os.cpu_count(), which reports the HOST's cores in a
+# container - 48 children and ~4.4 GB resident. See railway.worker.toml and
+# issue #126. Railway's startCommand overrides this CMD; keep the two in sync.
+CMD ["celery", "-A", "querygrade", "worker", "--loglevel=info", "--concurrency=2"]

--- a/railway.worker.toml
+++ b/railway.worker.toml
@@ -8,4 +8,16 @@ dockerfilePath = "Dockerfile.worker"
 
 [deploy]
 # No preDeployCommand: migrations + init_superuser are owned by the web service.
-startCommand = "celery -A querygrade worker --loglevel=info"
+#
+# --concurrency is pinned deliberately. Celery's prefork pool defaults to
+# os.cpu_count(), which inside a Railway container reports the HOST's core
+# count (48), not this container's share. That forked 48 children, each
+# carrying its own dirtied copy of Django + pandas + scikit-learn +
+# matplotlib, for ~4.4 GB resident at ~0.002 vCPU of actual work - $46/mo of
+# a $60 Railway bill (issue #126). The real load is one monitor_ml_models
+# task every 15 min plus occasional user-triggered ML tasks; 2 is generous.
+#
+# CELERY_WORKER_MAX_MEMORY_PER_CHILD does not substitute for this: prefork
+# only checks a child for recycling after it FINISHES a task, so idle
+# children are never reclaimed.
+startCommand = "celery -A querygrade worker --loglevel=info --concurrency=2"


### PR DESCRIPTION
Closes #126.

## Problem

`querygrade-worker` held **4.36 GB resident on average, 24/7**, at an average CPU of **0.0016 vCPU** (max 0.24 over a 7-day window). At Railway's $10.24/GB-month that is **$45.67 of the $60.46** invoice for Jun 26 - Jul 26 2026. Every other service in the workspace sits between 0.1 and 0.5 GB.

Neither `railway.worker.toml` nor `Dockerfile.worker` passed `--concurrency`, so Celery's prefork pool fell back to `os.cpu_count()` - which inside a Railway container reports the **host's** core count. From the worker startup log (deployment `0cfa43c7`):

```
- *** --- * --- .> concurrency: 48 (prefork)
```

48 children, each with its own copy-on-write-dirtied copy of Django + pandas + scikit-learn + matplotlib.

`CELERY_WORKER_MAX_MEMORY_PER_CHILD = 200000` (settings.py:550) does not cover this - prefork only considers a child for recycling *after it finishes a task*, and 46 of the 48 never received one.

## Change

`--concurrency=2` in `railway.worker.toml` (what Railway actually runs) and in `Dockerfile.worker` (local parity), with comments in both explaining why the value is pinned rather than inferred.

Pinned via the CLI flag rather than `CELERY_WORKER_CONCURRENCY` in settings so the value is visible at the process that starts, and so a future container-size change cannot silently re-inherit the host core count.

Scheduled load is one `monitor_ml_models` task every 15 minutes (`querygrade/celery.py:beat_schedule`) plus occasional user-triggered ML tasks, so 2 is generous.

## Verification after deploy

1. Worker startup log reads `concurrency: 2 (prefork)`.
2. `MEMORY_USAGE_GB` for the service settles at roughly 0.4-0.6 GB, down from 4.36 GB.
3. `monitor_ml_models` still *completes* on schedule - so the drop is a smaller worker, not a worker that stopped draining the queue.

Projected saving: ~$40/month.