### PR TITLE
chore(retention): purge expired sessions, schedule cleanup, fix dead queues

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -24,4 +24,5 @@ COPY . .
 # prefork pool defaults to os.cpu_count(), which reports the HOST's cores in a
 # container - 48 children and ~4.4 GB resident. See railway.worker.toml and
 # issue #126. Railway's startCommand overrides this CMD; keep the two in sync.
-CMD ["celery", "-A", "querygrade", "worker", "--loglevel=info", "--concurrency=2"]
+CMD ["celery", "-A", "querygrade", "worker", "--loglevel=info", "--concurrency=2", \
+     "-Q", "celery,heavy_processing,light_processing,maintenance"]

--- a/analyzer/tasks/__init__.py
+++ b/analyzer/tasks/__init__.py
@@ -20,7 +20,7 @@ Do not rename task functions as this will break existing queued tasks.
 from .log_tasks import process_log_file_async
 
 # Maintenance tasks
-from .maintenance_tasks import cleanup_temp_files
+from .maintenance_tasks import cleanup_temp_files, purge_expired_sessions
 
 # ML monitoring tasks
 from .monitoring_tasks import monitor_ml_models
@@ -43,6 +43,7 @@ __all__ = [
     "analyze_database_schema_async",
     # Maintenance tasks
     "cleanup_temp_files",
+    "purge_expired_sessions",
     # Report tasks
     "generate_performance_report",
     # ML monitoring tasks

--- a/analyzer/tasks/maintenance_tasks.py
+++ b/analyzer/tasks/maintenance_tasks.py
@@ -11,9 +11,52 @@ import tempfile
 from typing import Any, Dict
 
 from celery import shared_task
+from django.contrib.sessions.models import Session
+from django.core.management import call_command
 from django.utils import timezone
 
 logger = logging.getLogger(__name__)
+
+
+@shared_task(name="analyzer.tasks.purge_expired_sessions")
+def purge_expired_sessions():
+    """
+    Delete django_session rows whose expire_date has passed.
+
+    Django never removes expired session rows on its own - the cookie stops
+    being honored at SESSION_COOKIE_AGE (1 hour here), but the row stays
+    forever. Every anonymous visitor that touches a view writing to the
+    session leaves one behind, so the table is the only unbounded-growth
+    surface in this database (4,905 rows / 1.8 MB of a 12 MB database when
+    this task was added, against zero registered users).
+
+    Delegates to the `clearsessions` management command so this stays
+    correct if SESSION_ENGINE ever moves off the DB backend.
+    """
+    try:
+        expired = Session.objects.filter(expire_date__lt=timezone.now()).count()
+        call_command("clearsessions")
+        remaining = Session.objects.count()
+
+        logger.info(
+            f"Session purge completed: removed {expired} expired sessions, "
+            f"{remaining} remaining"
+        )
+
+        return {
+            "status": "success",
+            "purged": expired,
+            "remaining": remaining,
+            "timestamp": timezone.now().isoformat(),
+        }
+
+    except Exception as exc:
+        logger.error(f"Error in session purge task: {str(exc)}")
+        return {
+            "status": "error",
+            "error": str(exc),
+            "timestamp": timezone.now().isoformat(),
+        }
 
 
 @shared_task(name="analyzer.tasks.cleanup_temp_files")

--- a/analyzer/test_maintenance_tasks.py
+++ b/analyzer/test_maintenance_tasks.py
@@ -1,0 +1,85 @@
+"""
+Tests for the retention/maintenance tasks.
+
+These guard the two properties that actually matter for storage growth:
+expired session rows are deleted, and live session rows are not.
+"""
+
+from datetime import timedelta
+
+from django.contrib.sessions.backends.db import SessionStore
+from django.contrib.sessions.models import Session
+from django.test import TestCase
+from django.utils import timezone
+
+from analyzer.tasks import purge_expired_sessions
+
+
+def _make_session(expire_offset):
+    """Create a real session row whose expire_date is now + expire_offset."""
+    store = SessionStore()
+    store["k"] = "v"
+    store.create()
+    Session.objects.filter(session_key=store.session_key).update(
+        expire_date=timezone.now() + expire_offset
+    )
+    return store.session_key
+
+
+class PurgeExpiredSessionsTests(TestCase):
+    def test_deletes_expired_and_keeps_live_sessions(self):
+        expired = [_make_session(timedelta(hours=-2)) for _ in range(3)]
+        live = [_make_session(timedelta(hours=2)) for _ in range(2)]
+        self.assertEqual(Session.objects.count(), 5)
+
+        result = purge_expired_sessions()
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["purged"], 3)
+        self.assertEqual(result["remaining"], 2)
+
+        # Assert the delta, not just the count: the right rows survived.
+        surviving = set(Session.objects.values_list("session_key", flat=True))
+        self.assertEqual(surviving, set(live))
+        for key in expired:
+            self.assertFalse(Session.objects.filter(session_key=key).exists())
+
+    def test_noop_when_nothing_expired(self):
+        live = [_make_session(timedelta(hours=2)) for _ in range(2)]
+
+        result = purge_expired_sessions()
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["purged"], 0)
+        self.assertEqual(Session.objects.count(), 2)
+        self.assertEqual(
+            set(Session.objects.values_list("session_key", flat=True)), set(live)
+        )
+
+
+class TaskRoutingTests(TestCase):
+    """
+    A task routed to a queue no worker consumes is silently never executed -
+    Celery accepts it, writes it to Redis, and it sits there. This asserts the
+    worker's -Q list covers every queue settings.CELERY_TASK_ROUTES names.
+    """
+
+    def test_worker_consumes_every_routed_queue(self):
+        import tomllib
+
+        from django.conf import settings
+
+        with open("railway.worker.toml", "rb") as fh:
+            start_command = tomllib.load(fh)["deploy"]["startCommand"]
+
+        self.assertIn("-Q ", start_command, "worker must pin its queue list")
+        declared = set(start_command.split("-Q ")[1].split()[0].split(","))
+
+        needed = {r["queue"] for r in settings.CELERY_TASK_ROUTES.values()}
+        needed.add("celery")  # default queue: unrouted tasks land here
+
+        self.assertEqual(
+            needed - declared,
+            set(),
+            "CELERY_TASK_ROUTES names a queue the worker does not consume",
+        )

--- a/querygrade/celery.py
+++ b/querygrade/celery.py
@@ -28,6 +28,20 @@ app.conf.beat_schedule = {
         "task": "analyzer.tasks.monitor_ml_models",
         "schedule": crontab(minute="*/15"),
     },
+    # Retention. Django never deletes expired session rows on its own, so
+    # django_session grows without bound - it was 4,905 rows / 1.8 MB of a
+    # 12 MB database with zero registered users. Daily at 04:10 UTC, off the
+    # :00/:15 marks so it never contends with monitor-ml-models.
+    "purge-expired-sessions": {
+        "task": "analyzer.tasks.purge_expired_sessions",
+        "schedule": crontab(hour=4, minute=10),
+    },
+    # cleanup_temp_files has always documented itself as "should be run via
+    # celery beat every hour" but was never actually scheduled.
+    "cleanup-temp-files": {
+        "task": "analyzer.tasks.cleanup_temp_files",
+        "schedule": crontab(minute=40),
+    },
 }
 
 

--- a/querygrade/settings.py
+++ b/querygrade/settings.py
@@ -537,12 +537,18 @@ PERFORMANCE_MONITORING_ENABLED = DEBUG
 SLOW_QUERY_THRESHOLD = 1.0  # Log queries taking longer than 1 second
 
 # Background task optimization
+# NOTE: every queue named here must appear in the worker's -Q list
+# (railway.worker.toml / Dockerfile.worker). A task routed to a queue no
+# worker consumes is not an error - it is accepted, written to Redis, and
+# sits there forever. Adding a route without updating -Q silently disables
+# the task and leaks broker memory.
 CELERY_TASK_ROUTES = {
     "analyzer.tasks.process_log_file_async": {"queue": "heavy_processing"},
     "analyzer.tasks.batch_analyze_queries": {"queue": "heavy_processing"},
     "analyzer.tasks.analyze_database_schema_async": {"queue": "heavy_processing"},
     "analyzer.tasks.generate_performance_report": {"queue": "light_processing"},
     "analyzer.tasks.cleanup_temp_files": {"queue": "maintenance"},
+    "analyzer.tasks.purge_expired_sessions": {"queue": "maintenance"},
 }
 
 # Memory optimization

--- a/railway.worker.toml
+++ b/railway.worker.toml
@@ -20,4 +20,9 @@ dockerfilePath = "Dockerfile.worker"
 # CELERY_WORKER_MAX_MEMORY_PER_CHILD does not substitute for this: prefork
 # only checks a child for recycling after it FINISHES a task, so idle
 # children are never reclaimed.
-startCommand = "celery -A querygrade worker --loglevel=info --concurrency=2"
+# -Q must list every queue in settings.CELERY_TASK_ROUTES plus the default
+# `celery` queue. Without it the worker consumed only `celery`, so the five
+# routed tasks (log processing, batch analysis, schema analysis, reports,
+# temp-file cleanup) were accepted, written to Redis, and never executed.
+# Only monitor_ml_models ran, because it is the one task with no route.
+startCommand = "celery -A querygrade worker --loglevel=info --concurrency=2 -Q celery,heavy_processing,light_processing,maintenance"


### PR DESCRIPTION
Follow-on to #127. Three storage-growth gaps found while tracing the Railway bill.

## 1. `django_session` grows forever

**4,905 rows / 1.8 MB of a 12 MB database, with zero registered users** - the largest table by a wide margin and the only unbounded one.

`SESSION_COOKIE_AGE = 3600` stops the cookie being honored after an hour, but Django never deletes the row, and `clearsessions` was not run anywhere in the repo. Every anonymous visitor leaves one behind permanently.

Adds `analyzer.tasks.purge_expired_sessions`, daily at 04:10 UTC. Delegates to the `clearsessions` management command so it stays correct if `SESSION_ENGINE` moves off the DB backend.

## 2. `cleanup_temp_files` was never scheduled

Its docstring has said *"Should be run via celery beat every hour"* since it was written, but `beat_schedule` only ever contained `monitor-ml-models`. Now scheduled hourly at :40.

## 3. Five tasks were routed to queues no worker consumed

Neither fix above would have worked on its own. The worker ran `celery -A querygrade worker` with no `-Q`, so it consumed only the default `celery` queue - while `CELERY_TASK_ROUTES` routes five tasks elsewhere:

| Task | Queue | Consumed? |
|---|---|---|
| `process_log_file_async` | `heavy_processing` | ❌ |
| `batch_analyze_queries` | `heavy_processing` | ❌ |
| `analyze_database_schema_async` | `heavy_processing` | ❌ |
| `generate_performance_report` | `light_processing` | ❌ |
| `cleanup_temp_files` | `maintenance` | ❌ |
| `monitor_ml_models` | *(unrouted)* → `celery` | ✅ |

Celery does not error on a task routed to an unconsumed queue - it accepts it, writes it to Redis, and leaves it there. So those four product tasks have been silently dead, and would have grown the broker without bound under real traffic.

**Verified against production Redis** before changing anything: all four queues empty, `dbsize` 8, 1.74 MB used. Nothing has accumulated - the tasks were never *enqueued*, rather than enqueued and dropped, because the app currently has no traffic. So this is a latent bug, not an active leak.

The worker now pins `-Q celery,heavy_processing,light_processing,maintenance`.

## Verification

- `analyzer/test_maintenance_tasks.py` asserts the **delta**, not the count: expired rows are gone *and* the live rows are exactly the ones that survive.
- A routing test parses `railway.worker.toml` and fails if `CELERY_TASK_ROUTES` names a queue absent from `-Q`, so adding a route without updating the worker breaks CI instead of silently disabling a task.
- **Mutation-checked.** Removing the `clearsessions` call fails only the purge test (`5 != 2`); dropping `maintenance` from `-Q` fails only the routing test. Restored baseline green.
- Full suite: **778 tests, OK (skipped=14)**.

## Note on scope

Fixing `-Q` means `process_log_file_async`, `batch_analyze_queries`, `analyze_database_schema_async` and `generate_performance_report` will start actually executing when something enqueues them. That is the intended behavior of the product, but it is a behavior change beyond retention, called out here deliberately.