### PR TITLE
Drop unimported heavy deps from the worker image

### DIFF
--- a/analyzer/management/commands/load_huggingface_queries.py
+++ b/analyzer/management/commands/load_huggingface_queries.py
@@ -114,7 +114,9 @@ class Command(BaseCommand):
             raise CommandError(
                 "The `datasets` package is required. Install with:\n"
                 "    pip install --break-system-packages datasets\n"
-                "(or add to requirements-worker.txt)"
+                "It is in requirements.txt (local/dev) but deliberately not in\n"
+                "requirements-worker.txt - see issue #130. Running this against\n"
+                "Railway means installing it in that container first."
             ) from exc
 
         dataset_id = options["dataset"]

--- a/analyzer/test_requirements_hygiene.py
+++ b/analyzer/test_requirements_hygiene.py
@@ -1,0 +1,115 @@
+"""Guards on requirements-worker.txt.
+
+The worker image once carried torch (plus the whole NVIDIA CUDA stack),
+transformers, sentence-transformers, lightgbm and matplotlib with zero import
+sites anywhere in the tree - several GB of layers and ~2 min of build time per
+deploy for code that did not exist (issue #130).
+
+Nothing failed when they were there, which is why they survived so long: an
+unused dependency is invisible to every other test in the suite. This file is
+the check that notices.
+"""
+
+import re
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKER_REQUIREMENTS = REPO_ROOT / "requirements-worker.txt"
+
+# Distribution name -> the module name you would actually import. Only needed
+# where the two differ; anything absent falls back to the normalized dist name.
+IMPORT_NAME_OVERRIDES = {
+    "scikit-learn": "sklearn",
+    "sentence-transformers": "sentence_transformers",
+    "psycopg2-binary": "psycopg2",
+    "pillow": "PIL",
+    "beautifulsoup4": "bs4",
+    "python-decouple": "decouple",
+}
+
+
+def _parse_requirements(path):
+    """Return the distribution names pinned directly in `path`.
+
+    Skips comments, blank lines and `-r` includes - the point is what THIS
+    file adds on top of requirements-prod.txt.
+    """
+    names = []
+    for raw in path.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):
+            continue
+        # Strip extras, version specifiers and environment markers.
+        name = re.split(r"[\[<>=!~;]", line, 1)[0].strip()
+        if name:
+            names.append(name)
+    return names
+
+
+def _import_name(dist_name):
+    key = dist_name.lower()
+    return IMPORT_NAME_OVERRIDES.get(key, key.replace("-", "_"))
+
+
+def _has_import_site(module):
+    """True if any tracked .py file imports `module` at a real import site."""
+    pattern = re.compile(
+        rf"^[ \t]*(?:import[ \t]+{re.escape(module)}\b"
+        rf"|from[ \t]+{re.escape(module)}[\. \t])",
+        re.MULTILINE,
+    )
+    for py_file in REPO_ROOT.rglob("*.py"):
+        parts = py_file.parts
+        if any(p in {".venv", "venv", "node_modules", "migrations"} for p in parts):
+            continue
+        try:
+            if pattern.search(py_file.read_text(errors="ignore")):
+                return True
+        except OSError:
+            continue
+    return False
+
+
+class WorkerRequirementsTests(SimpleTestCase):
+    def test_every_worker_dependency_is_actually_imported(self):
+        """Every dep pinned in requirements-worker.txt has a real import site.
+
+        This is the rule that torch, transformers, sentence-transformers,
+        lightgbm and matplotlib all violated. Adding any of them back without
+        a corresponding import fails here.
+        """
+        unused = []
+        for dist in _parse_requirements(WORKER_REQUIREMENTS):
+            module = _import_name(dist)
+            if not _has_import_site(module):
+                unused.append(f"{dist} (looked for `import {module}`)")
+
+        self.assertEqual(
+            unused,
+            [],
+            "requirements-worker.txt pins packages that nothing imports. Each "
+            "one costs image size and build time on every worker deploy for "
+            "code that does not exist. Either add the import or drop the "
+            "dependency (issue #130). Unused: " + ", ".join(unused),
+        )
+
+    def test_guard_detects_an_unimported_package(self):
+        """The guard above is only meaningful if it can actually fail.
+
+        Asserting a known-absent package is reported keeps the detector honest:
+        if _has_import_site ever started returning True for everything, the
+        real test would pass vacuously and this one would fail.
+        """
+        self.assertFalse(
+            _has_import_site("torch"),
+            "Expected no torch import site. If torch is genuinely used now, "
+            "add it back to requirements-worker.txt and update this test.",
+        )
+        self.assertTrue(
+            _has_import_site("xgboost"),
+            "Expected to find the xgboost import in analyzer/ml/ensemble/"
+            "multi_model.py. If this fails the detector is broken, not the "
+            "requirements file.",
+        )

--- a/railway.worker.toml
+++ b/railway.worker.toml
@@ -12,8 +12,8 @@ dockerfilePath = "Dockerfile.worker"
 # --concurrency is pinned deliberately. Celery's prefork pool defaults to
 # os.cpu_count(), which inside a Railway container reports the HOST's core
 # count (48), not this container's share. That forked 48 children, each
-# carrying its own dirtied copy of Django + pandas + scikit-learn +
-# matplotlib, for ~4.4 GB resident at ~0.002 vCPU of actual work - $46/mo of
+# carrying its own dirtied copy of Django + pandas + scikit-learn,
+# for ~4.4 GB resident at ~0.002 vCPU of actual work - $46/mo of
 # a $60 Railway bill (issue #126). The real load is one monitor_ml_models
 # task every 15 min plus occasional user-triggered ML tasks; 2 is generous.
 #

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,7 +1,7 @@
 # Slim production deps for the Railway web service.
-# Excludes heavy ML frameworks (tensorflow/torch/transformers/xgboost/lightgbm/matplotlib)
-# which are only used inside analyzer/ml/ensemble/ and analyzer/ml/training/.
-# Those run in the separate Celery worker service (see requirements-worker.txt).
+# Excludes the heavy ML frameworks (tensorflow, xgboost), which are only used
+# inside analyzer/ml/ensemble/ and analyzer/ml/training/ and run in the separate
+# Celery worker service (see requirements-worker.txt).
 #
 # Upper bounds are load-bearing here, not tidiness: this file is installed fresh
 # on every deploy, so an unbounded `>=` floor silently ships whatever major

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -3,23 +3,22 @@
 
 -r requirements-prod.txt
 
-# Heavy ML frameworks - only loaded by analyzer/ml/ensemble and analyzer/ml/training
+# Heavy ML frameworks - the only import sites are in
+# analyzer/ml/ensemble/multi_model.py.
 #
-# CAUTION: the caps below record what these floors ALREADY resolve to, not a
-# version anyone verified. Six of them had silently crossed majors while the
-# floors still claimed the old one (torch 1 -> 2, transformers 4 -> 5,
-# sentence-transformers 2 -> 5, xgboost 1 -> 3, lightgbm 3 -> 4, datasets
-# 2 -> 5). These deps are not installed in the local .venv, so the test suite
+# Keep this list to what is actually imported. torch (plus the whole NVIDIA
+# CUDA stack it pulls in), transformers, sentence-transformers, lightgbm and
+# matplotlib were all pinned here with ZERO import sites anywhere in the tree -
+# several GB of image layers and ~2 min of build time on every worker deploy,
+# for code that does not exist (issue #130). The only `torch` reference left in
+# the repo is a prose comment. Before adding any of them back, grep for a real
+# import first; an entry here is not evidence that anything uses it.
+#
+# CAUTION: the caps record what these floors ALREADY resolve to, not a version
+# anyone verified - xgboost had silently crossed 1 -> 3 while the floor still
+# claimed 1. These deps are not installed in the local .venv, so the test suite
 # does not cover them; the caps freeze the drift rather than bless it. Anything
 # in analyzer/ml/ensemble or analyzer/ml/training should be treated as
 # unverified against these majors until it runs.
-matplotlib>=3.10.9,<4.0
 tensorflow>=2.10.0,<3.0
-torch>=1.13.0,<3.0
-transformers>=4.25.0,<6.0
-sentence-transformers>=2.2.0,<6.0
 xgboost>=1.7.0,<4.0
-lightgbm>=3.3.0,<5.0
-
-# HuggingFace datasets - used by load_huggingface_queries to seed TrainingData
-datasets>=2.14.0,<6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,14 @@ joblib>=1.5.3,<2.0
 beautifulsoup4>=4.12.0,<5.0
 requests>=2.31.0,<3.0
 
+# Optional, local/manual only: the `load_huggingface_queries` seeding command.
+# Deliberately NOT in requirements-worker.txt - it drags in pyarrow and friends
+# for one manually-run management command that is not on any worker code path.
+# The command already raises a CommandError naming the install when it is
+# missing, so the failure is loud and self-explaining. To run it against
+# Railway, pip install it inside that container first.
+datasets>=2.14.0,<6.0
+
 # Testing & Coverage
 coverage>=7.13.5,<8.0
 # Test-only: memory assertions in analyzer/ml/tests. Deliberately absent from


### PR DESCRIPTION
Closes #130.

## What

Removes five packages from `requirements-worker.txt` that nothing imports:

| Package | Import sites |
|---|---|
| `torch` (+ the NVIDIA CUDA stack it drags in) | 0 |
| `transformers` | 0 |
| `sentence-transformers` | 0 |
| `lightgbm` | 0 |
| `matplotlib` | 0 |

`tensorflow` (3 sites) and `xgboost` (1 site) stay - both are imported by `analyzer/ml/ensemble/multi_model.py`.

`datasets` moves to `requirements.txt`. Its only use is a lazy import inside the `load_huggingface_queries` management command, which is run by hand and is not on any worker code path. That command already raised a `CommandError` naming the install; the message now also says where the dependency lives, so it stays accurate.

## What this is and is not worth

It does **not** reduce the Railway bill. Image size is not a billed line, and unimported packages do not occupy worker RSS. #126 already captured the real money - $45.67/mo of idle worker memory.

What it buys is about 2 minutes off every worker deploy and several GB of image layers.

## Guard

An unused dependency is invisible to every other test in the suite, which is why these survived as long as they did. Added `analyzer/test_requirements_hygiene.py`:

- `test_every_worker_dependency_is_actually_imported` - every package pinned in `requirements-worker.txt` must have a real import site.
- `test_guard_detects_an_unimported_package` - keeps the detector honest by asserting it still reports `torch` absent and `xgboost` present, so the first test cannot start passing vacuously.

Both mutation-checked, each producing exactly one targeted failure:

- appending `torch>=1.13.0,<3.0` back: `AssertionError: Lists differ: ['torch (looked for `import torch`)'] != []`
- stubbing `_has_import_site` to `return True`: `AssertionError: True is not false : Expected no torch import site.`

Baseline restored after each. Full suite: **780 tests, OK (skipped=14)**.

## Also

Two comments in `railway.worker.toml` and `requirements-prod.txt` named `matplotlib` as part of the worker's resident memory. It was installed but never imported, so it was never resident - corrected rather than left to mislead the next reader.

## Verification still owed

The local `.venv` does not install these deps, so the suite has never exercised `multi_model.py`. Merging this needs a worker deploy that comes up healthy and executes a task before it counts as proven.
