### PR TITLE
Record Redis/Postgres service configuration in the repo

### DIFF
--- a/DOCUMENTATION_MAP.md
+++ b/DOCUMENTATION_MAP.md
@@ -30,6 +30,11 @@ QueryGrade Documentation
 │       ├── analyzer/test_integration_refactored.py (working implementation)
 │       └── analyzer/performance.py (cache singleton)
 │
+├── infra/railway-services.md (Datastore Service Configuration)
+│   └── Referenced by:
+│       ├── railway.toml (sibling-services comment)
+│       └── scripts/check-railway-datastore-config.sh (live drift check)
+│
 └── analyzer/test_integration_refactored.py (Test Implementation)
     └── References:
         ├── TESTING.md (testing guide)
@@ -44,6 +49,7 @@ QueryGrade Documentation
 | **README.md** | Project introduction, quick start, features overview | New users, evaluators |
 | **.github/CONTRIBUTING.md** | Development setup, coding standards, PR process | Contributors |
 | **docs/specs/** | Per-feature design specs written before implementation | Developers picking up a feature |
+| **infra/railway-services.md** | Redis/Postgres runtime settings and the reasoning behind each non-default flag | Anyone changing a deployed datastore service |
 | **TESTING.md** | Comprehensive testing guide with examples and troubleshooting | Developers writing tests |
 | **INTEGRATION_TEST_FIX_SUMMARY.md** | Detailed case study of debugging cache initialization issue | Advanced developers, troubleshooting |
 | **test_integration_refactored.py** | Working test implementation with inline documentation | Developers writing integration tests |
@@ -61,6 +67,7 @@ QueryGrade Documentation
 - **Add new analyzers** → [README.md](README.md) (Project Structure section) and `analyzer/analyzers/`
 - **Set up development environment** → [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) (Development Setup section)
 - **Contribute to the project** → [README.md](README.md) (Contributing section)
+- **Change the Redis or Postgres service** → [infra/railway-services.md](infra/railway-services.md)
 
 ## Documentation Quality Standards
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ QueryGrade/
 │   ├── templates/       # HTML templates
 │   └── static/          # CSS, JS, images
 ├── scripts/             # Developer utilities (og:image card, ML integration check)
+├── infra/               # Deployed datastore service config and rationale
 ├── requirements.txt     # Python dependencies (full, includes test deps)
 ├── requirements-prod.txt # Slim deps for the deployed web service
 ├── Dockerfile          # Local dev image, used by docker-compose

--- a/infra/railway-services.md
+++ b/infra/railway-services.md
@@ -1,0 +1,119 @@
+# Railway service configuration
+
+The app services carry their own configuration in this repo: `railway.toml`,
+`railway.worker.toml` and `railway.beat.toml` hold the build and start commands,
+with the reasoning behind each non-obvious flag in a comment next to it.
+
+Redis and Postgres cannot work that way. They are image services with no repo
+source, so there is no file for Railway to read and their entire runtime
+configuration lives in the dashboard. This file is the reviewable record for
+those two: what is set, and why it must stay that way.
+
+Read it before changing a datastore service, and update it in the same change.
+
+Project `e2426fe6-a773-43e3-8bb4-ef96921e8546`, environment `production`
+(`460d0b79-8991-4cad-a4e2-39c0b0532fca`).
+
+## Redis (service `8e5c610a-a078-4be5-a7ce-211c203e5d04`)
+
+Celery broker and result backend. Also backs the Django caches.
+
+- Image: `redis:8.2.1`
+- Volume `/data`, exposed to the start command as `$RAILWAY_VOLUME_MOUNT_PATH`
+- Private endpoint `redis`, TCP proxy on 6379
+
+Start command:
+
+```
+/bin/sh -c "rm -rf $RAILWAY_VOLUME_MOUNT_PATH/lost+found/ && exec docker-entrypoint.sh redis-server --requirepass $REDIS_PASSWORD --save 60 1 --dir $RAILWAY_VOLUME_MOUNT_PATH --maxmemory 256mb --maxmemory-policy noeviction"
+```
+
+Every flag past `redis-server`, and why:
+
+| Flag | Why |
+| --- | --- |
+| `--requirepass $REDIS_PASSWORD` | The TCP proxy makes the port publicly reachable. |
+| `--save 60 1` | RDB snapshot after 60s if at least one key changed. Queued tasks survive a restart. |
+| `--dir $RAILWAY_VOLUME_MOUNT_PATH` | Without it the snapshot lands on the ephemeral container filesystem and the volume is pointless. |
+| `--maxmemory 256mb` | Ceiling. See below. |
+| `--maxmemory-policy noeviction` | **Do not change this.** See below. |
+
+The `rm -rf .../lost+found/` prefix comes from the Railway Redis template. The
+volume is ext4, so it has a `lost+found` directory at its root, and Redis
+refuses to treat a non-empty unexpected directory as its data dir.
+
+### The two flags whose failure modes are silent
+
+**`--maxmemory 256mb`** (issue #129). Redis has no memory ceiling by default. It
+grows until the container is OOM-killed, which on Railway is billed the whole
+way up. 256mb is roughly 40x the working set: the broker holds a handful of
+queued tasks plus cache entries, and measured usage sits in the 5-7 MB range.
+The cap is there to bound a runaway, not to be approached in normal operation.
+
+**`--maxmemory-policy noeviction`** is stated explicitly rather than left to the
+default *because* it is the default. An `--maxmemory` value with no policy
+alongside it reads like an oversight and invites someone to "fix" it by adding
+`allkeys-lru`, which is the correct choice for a pure cache and the wrong one
+here. This Redis is a Celery broker. Under an eviction policy, hitting the
+ceiling makes Redis delete queued task payloads to make room: jobs disappear
+with no error at either end, and nothing surfaces the loss. Under `noeviction`
+the producer gets a loud `OOM command not allowed` write error instead, which
+is recoverable and shows up in logs.
+
+The tradeoff is deliberate. Cache writes fail at the ceiling too, since the
+caches share this instance. A failed cache write is a slow request; a silently
+dropped Celery task is missing work nobody knows about.
+
+### Verify
+
+```
+railway ssh -s Redis 'redis-cli -a "$REDIS_PASSWORD" --no-auth-warning config get maxmemory maxmemory-policy'
+```
+
+Expect `maxmemory 268435456` and `maxmemory-policy noeviction`.
+
+Two traps when checking this after a change:
+
+- A runtime `CONFIG SET` and a start-command flag read back identically. If you
+  have been testing with `CONFIG SET`, revert it first, and confirm
+  `redis-cli info server | grep uptime_in_seconds` is low enough to prove the
+  process actually restarted. Otherwise a passing read proves nothing.
+- Railway's `redeploy` restarts the container but does not pick up a changed
+  start command, and reports success either way. Use a fresh deploy
+  (`serviceInstanceDeployV2`, or the dashboard's Deploy) after editing it.
+
+`scripts/check-railway-datastore-config.sh` runs the check and compares against
+the values documented here.
+
+## Postgres (service `ce0d937f-1a9b-4a84-86bf-767c4e866eba`)
+
+Primary application database.
+
+- Image: `ghcr.io/railwayapp-templates/postgres-ssl:18`
+- Volume `/var/lib/postgresql/data`
+- Private endpoint `postgres`, TCP proxy on 5432
+- **No start command override.** The template image's entrypoint is used as-is.
+
+Recorded here so that "nothing is set" is a documented state rather than an
+unknown one. The service runs on template defaults, including
+`shared_buffers` and `max_connections`. If a tuning flag is ever added, it
+belongs in this file with its reasoning before it is applied.
+
+`SSL_CERT_DAYS` and `RAILWAY_DEPLOYMENT_DRAINING_SECONDS` are template variables,
+not application configuration.
+
+## Why this is a document and not a config file
+
+The alternative is a checked-in `redis.conf` mounted into the service, which
+would make these settings diffable in the normal way. It does not fit: the
+service's source is a public image, so it has no access to this repo's files.
+Getting a config file in would mean building Redis from a Dockerfile here,
+which adds a build to every Redis change and takes on maintenance of an image
+that currently updates itself.
+
+The honest limitation is that this file cannot enforce anything. Someone can
+still change the start command in the dashboard and never open this file. What
+it does buy is that the setting and its reasoning are reviewable, survive in
+git history, and are recoverable if a service is recreated from the template.
+`scripts/check-railway-datastore-config.sh` closes part of the gap by checking
+the live values on demand.

--- a/railway.toml
+++ b/railway.toml
@@ -12,11 +12,20 @@ startCommand = "sh -c 'python manage.py collectstatic --noinput && gunicorn quer
 # ---------------------------------------------------------------------------
 # Sibling services (provisioned in the Railway dashboard, not via railway.toml):
 #
-#   querygrade-worker  — Dockerfile.worker — Celery worker, executes ML tasks
-#   querygrade-beat    — Dockerfile.beat   — Celery beat, schedules monitor_ml_models
+#   querygrade-worker  - Dockerfile.worker - Celery worker, executes ML tasks
+#   querygrade-beat    - Dockerfile.beat   - Celery beat, schedules monitor_ml_models
 #                                            every 15 min (see querygrade/celery.py)
 #
 # Both services share the same env vars as the web service (DATABASE_URL,
 # REDIS_URL, etc.). Beat additionally needs ML_ALERT_RECIPIENTS once PR 3
 # of the issue-#5 stack lands.
+#
+#   Redis    - image service, Celery broker + Django cache backend
+#   Postgres - image service, application database
+#
+# Those two are image services with no repo source, so they have no config file
+# here and their settings live only in the Railway dashboard. infra/railway-services.md
+# is the record of what is set on them and why. Read it before changing either;
+# Redis in particular carries a memory ceiling and an eviction policy whose
+# failure modes are silent.
 # ---------------------------------------------------------------------------

--- a/scripts/check-railway-datastore-config.sh
+++ b/scripts/check-railway-datastore-config.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Compare the live Redis broker settings against the values recorded in
+# infra/railway-services.md.
+#
+# Not part of the local test gate: it needs the Railway CLI, an authenticated
+# session, and a running service. Run it after changing a datastore service, or
+# when a service has been recreated, to confirm the deployed configuration still
+# matches the documented one.
+#
+# Usage:  scripts/check-railway-datastore-config.sh
+# Exit:   0 all settings match, 1 a mismatch, 2 could not check.
+
+set -uo pipefail
+
+REDIS_SERVICE="${REDIS_SERVICE:-Redis}"
+
+# Keep in sync with infra/railway-services.md. 268435456 = 256mb.
+EXPECT_MAXMEMORY="268435456"
+EXPECT_POLICY="noeviction"
+
+if ! command -v railway >/dev/null 2>&1; then
+  echo "railway CLI not found. Install it or run the redis-cli check by hand;" >&2
+  echo "infra/railway-services.md has the command." >&2
+  exit 2
+fi
+
+raw=$(railway ssh -s "$REDIS_SERVICE" \
+  'redis-cli -a "$REDIS_PASSWORD" --no-auth-warning config get maxmemory maxmemory-policy' 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "railway ssh failed (exit $rc):" >&2
+  echo "$raw" >&2
+  exit 2
+fi
+
+# CONFIG GET returns alternating key/value lines, in unspecified order, after
+# whatever the CLI prints about the SSH key. Pick the value out by its key.
+value_of() {
+  echo "$raw" | awk -v want="$1" '
+    $0 == want { getline v; print v; found = 1; exit }
+    END { if (!found) exit 1 }
+  '
+}
+
+fail=0
+check() {
+  local key="$1" expected="$2" actual
+  if ! actual=$(value_of "$key"); then
+    echo "FAIL  $key: not present in CONFIG GET output" >&2
+    fail=1
+    return
+  fi
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL  $key: expected '$expected', got '$actual'" >&2
+    fail=1
+    return
+  fi
+  echo "ok    $key = $actual"
+}
+
+check maxmemory "$EXPECT_MAXMEMORY"
+check maxmemory-policy "$EXPECT_POLICY"
+
+if [ "$fail" -ne 0 ]; then
+  cat >&2 <<'MSG'
+
+The deployed Redis configuration does not match infra/railway-services.md.
+Either the service drifted (start command edited, or the service was recreated
+from the Railway template, which restores the default command and drops both
+flags), or the documented values are stale.
+
+maxmemory-policy is the one to look at first: an eviction policy on a Celery
+broker silently deletes queued tasks under memory pressure. See the Redis
+section of infra/railway-services.md.
+MSG
+  exit 1
+fi
+
+echo
+echo "Redis matches infra/railway-services.md."


### PR DESCRIPTION
Closes #131.

Redis and Postgres are image services with no repo source, so unlike the app services they have no `railway.*.toml` and their entire runtime configuration lives only in the Railway dashboard.

## What this adds

**`infra/railway-services.md`** - the record. Per service: source image, volume mounts, networking, start command, and the reasoning behind each non-default flag. It also records that Postgres has *no* start-command override, so "nothing is set" is a documented state rather than an unknown one.

The two settings this exists for are on Redis, and both fail silently:

- `--maxmemory 256mb` (#129). No ceiling by default; Redis grows until the container is OOM-killed, billed the whole way up.
- `--maxmemory-policy noeviction`. Stated explicitly *because* it is the default - a `--maxmemory` with no policy beside it reads like an oversight and invites someone to add `allkeys-lru`, which is right for a cache and wrong for a broker. Evicting at the ceiling deletes queued Celery task payloads with no error at either end. `noeviction` gives the producer a write error instead.

**`scripts/check-railway-datastore-config.sh`** - compares the live values against the documented ones, so the doc is checkable rather than purely aspirational. Not in the test gate: it needs the Railway CLI, an authenticated session, and a running service. It exits 2 when it cannot check and 1 on a real mismatch, so a missing CLI never reads as a pass.

Plus cross-references from `railway.toml`, `README.md` and `DOCUMENTATION_MAP.md`, and dash normalization in the `railway.toml` comment block.

## Why a document rather than a checked-in `redis.conf`

The issue offered both. A config file does not fit: the service's source is a public image with no access to this repo, so getting one in would mean building Redis from a Dockerfile here - a build on every Redis change, and maintenance of an image that currently updates itself.

The limitation is stated in the file: it cannot enforce anything. Someone can still edit the start command in the dashboard and never open it. What it buys is that the setting and its reasoning are reviewable, survive in git history, and are recoverable if a service is recreated. The script closes part of that gap.

## Verification

- Live config read from Railway; documented values match what is deployed (`maxmemory 268435456`, `maxmemory-policy noeviction`).
- Drift script mutation-checked four ways: wrong `maxmemory` expectation, wrong policy expectation, a key that does not exist, and no Railway CLI on PATH. Each fails on exactly its own row with the other still reporting ok, and the CLI-absent case exits 2 rather than 1 or 0.
- All three `railway.*.toml` files still parse.
- All internal markdown links resolve; no broken references introduced.
- `manage.py test`: 780 tests, OK (skipped=14).