### PR TITLE
Purge expired sessions from the web process when beat is not running

### DIFF
--- a/analyzer/middleware.py
+++ b/analyzer/middleware.py
@@ -4,6 +4,7 @@ Custom security middleware for enhanced CSRF and XSS protection.
 
 import logging
 import re
+import time
 
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
@@ -223,3 +224,74 @@ class CSRFFailureMiddleware(MiddlewareMixin):
         else:
             ip = request.META.get("REMOTE_ADDR")
         return ip
+
+
+class SessionPurgeMiddleware:
+    """
+    Run the expired-session purge from the web process, at most once per
+    SESSION_PURGE_INTERVAL_SECONDS.
+
+    Retention is normally beat's job (``purge-expired-sessions``, daily at
+    04:10 UTC). The worker and beat services are stopped while QueryGrade has
+    no users, because a full-time pair cost about $6.90/month to delete on the
+    order of 100-150 session rows a day (issue #133). This middleware keeps
+    the one piece of that work that still matters running on a service that is
+    already up, at no additional cost.
+
+    It is safe to leave enabled when beat comes back. Both callers take the
+    same cache lock, so whichever runs first wins the interval and the other
+    finds nothing to do.
+
+    Design constraints, in the order they matter:
+
+    1. The common path must be free. Almost every request should do no I/O to
+       decide it is not time yet, so the first check is an in-process
+       monotonic deadline - no cache round-trip, no query. The deadline is
+       per-process and resets on restart, which costs at most one extra cache
+       lookup per process.
+    2. It must never break a request. The purge runs inside a try/except that
+       swallows everything; a broken cache or database makes retention stop,
+       not the site.
+    3. It must not hot-loop when something is failing. The local deadline is
+       pushed forward *before* the attempt, so a failing purge is retried on
+       the next interval rather than on the next request.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # Zero rather than "now + interval": the first request after a deploy
+        # should be eligible, otherwise a service that restarts more often
+        # than the interval would never purge at all.
+        self._next_attempt = 0.0
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        self._maybe_purge()
+        return response
+
+    def _maybe_purge(self):
+        interval = getattr(settings, "SESSION_PURGE_INTERVAL_SECONDS", 86400)
+        if not interval or not getattr(settings, "SESSION_PURGE_IN_REQUEST", True):
+            return
+
+        now = time.monotonic()
+        if now < self._next_attempt:
+            return
+        self._next_attempt = now + interval
+
+        try:
+            from django.core.cache import cache
+
+            from analyzer.tasks.maintenance_tasks import purge_expired_sessions_now
+
+            # add() is atomic, so exactly one process/replica wins the
+            # interval. The entry expires with the interval, which is what
+            # schedules the next run.
+            if not cache.add("session_purge_lock", "1", interval):
+                return
+
+            result = purge_expired_sessions_now()
+            logger.info("In-request session purge: %s", result)
+        except Exception as exc:
+            # Retention failing must never surface to a visitor.
+            logger.warning("In-request session purge skipped: %s", exc)

--- a/analyzer/tasks/maintenance_tasks.py
+++ b/analyzer/tasks/maintenance_tasks.py
@@ -18,8 +18,7 @@ from django.utils import timezone
 logger = logging.getLogger(__name__)
 
 
-@shared_task(name="analyzer.tasks.purge_expired_sessions")
-def purge_expired_sessions():
+def purge_expired_sessions_now():
     """
     Delete django_session rows whose expire_date has passed.
 
@@ -28,10 +27,18 @@ def purge_expired_sessions():
     forever. Every anonymous visitor that touches a view writing to the
     session leaves one behind, so the table is the only unbounded-growth
     surface in this database (4,905 rows / 1.8 MB of a 12 MB database when
-    this task was added, against zero registered users).
+    this was added, against zero registered users). Observed accumulation is
+    roughly 100-150 rows a day from crawler traffic alone.
 
     Delegates to the `clearsessions` management command so this stays
     correct if SESSION_ENGINE ever moves off the DB backend.
+
+    This is a plain function, not only a Celery task, because it has two
+    callers. The beat schedule runs it daily when the worker is up, and
+    SessionPurgeMiddleware runs it from the web process when it is not
+    (issue #133 - the worker and beat services are stopped for cost while
+    QueryGrade has no users). Never assume it runs on a worker: it must stay
+    safe to call inline in a request.
     """
     try:
         expired = Session.objects.filter(expire_date__lt=timezone.now()).count()
@@ -57,6 +64,12 @@ def purge_expired_sessions():
             "error": str(exc),
             "timestamp": timezone.now().isoformat(),
         }
+
+
+@shared_task(name="analyzer.tasks.purge_expired_sessions")
+def purge_expired_sessions():
+    """Celery entry point for :func:`purge_expired_sessions_now`."""
+    return purge_expired_sessions_now()
 
 
 @shared_task(name="analyzer.tasks.cleanup_temp_files")

--- a/analyzer/test_session_purge_middleware.py
+++ b/analyzer/test_session_purge_middleware.py
@@ -1,0 +1,230 @@
+"""Tests for SessionPurgeMiddleware (issue #133).
+
+The middleware is the only thing purging expired sessions while the worker and
+beat services are stopped, so these cover the guarantees that matter: it runs,
+it runs at most once per interval, it survives a broken cache or database, and
+it never delays the response path more than once per interval.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest import mock
+
+from django.contrib.sessions.models import Session
+from django.core.cache import cache
+from django.http import HttpResponse
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from analyzer.middleware import SessionPurgeMiddleware
+
+PURGE_PATH = "analyzer.tasks.maintenance_tasks.purge_expired_sessions_now"
+
+
+def _make_session(expired: bool) -> Session:
+    offset = timedelta(hours=-1) if expired else timedelta(hours=1)
+    return Session.objects.create(
+        session_key=f"{'x' if expired else 'y'}{Session.objects.count():031d}",
+        session_data="e30=",
+        expire_date=timezone.now() + offset,
+    )
+
+
+@override_settings(
+    SESSION_PURGE_IN_REQUEST=True,
+    SESSION_PURGE_INTERVAL_SECONDS=86400,
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+)
+class SessionPurgeMiddlewareTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        Session.objects.all().delete()
+        self.response = HttpResponse("ok")
+        self.calls = []
+
+    def _middleware(self):
+        def get_response(request):
+            self.calls.append(request)
+            return self.response
+
+        return SessionPurgeMiddleware(get_response)
+
+    def test_expired_sessions_are_deleted_on_a_request(self):
+        _make_session(expired=True)
+        _make_session(expired=True)
+        live = _make_session(expired=False)
+
+        mw = self._middleware()
+        response = mw(mock.Mock())
+
+        self.assertIs(response, self.response)
+        self.assertEqual(
+            list(Session.objects.values_list("session_key", flat=True)),
+            [live.session_key],
+        )
+
+    def test_purge_runs_at_most_once_per_interval(self):
+        mw = self._middleware()
+        with mock.patch(PURGE_PATH, return_value={"status": "success"}) as purge:
+            for _ in range(5):
+                mw(mock.Mock())
+        self.assertEqual(purge.call_count, 1)
+
+    def test_a_second_process_does_not_repeat_the_purge_in_the_same_interval(self):
+        """The in-process deadline is per instance, so the cache lock is what
+        stops a second worker (or a restarted one) purging again."""
+        with mock.patch(PURGE_PATH, return_value={"status": "success"}) as purge:
+            self._middleware()(mock.Mock())
+            self._middleware()(mock.Mock())
+        self.assertEqual(purge.call_count, 1)
+
+    def test_purge_runs_again_once_the_interval_has_passed(self):
+        mw = self._middleware()
+        with mock.patch(PURGE_PATH, return_value={"status": "success"}) as purge:
+            mw(mock.Mock())
+            # Expire both gates: the in-process deadline and the cache lock.
+            mw._next_attempt = 0.0
+            cache.delete("session_purge_lock")
+            mw(mock.Mock())
+        self.assertEqual(purge.call_count, 2)
+
+    def test_response_is_returned_when_the_purge_raises(self):
+        _make_session(expired=True)
+        mw = self._middleware()
+        with mock.patch(PURGE_PATH, side_effect=RuntimeError("db is down")):
+            response = mw(mock.Mock())
+        self.assertIs(response, self.response)
+        self.assertEqual(len(self.calls), 1)
+
+    def test_response_is_returned_when_the_cache_is_unreachable(self):
+        mw = self._middleware()
+        with mock.patch(
+            "django.core.cache.cache.add", side_effect=RuntimeError("redis is down")
+        ):
+            response = mw(mock.Mock())
+        self.assertIs(response, self.response)
+
+    def test_a_failed_attempt_does_not_retry_on_the_next_request(self):
+        """The deadline is pushed forward before the attempt, so a failing
+        purge costs one try per interval and not one per request."""
+        mw = self._middleware()
+        with mock.patch(PURGE_PATH, side_effect=RuntimeError("boom")) as purge:
+            for _ in range(4):
+                mw(mock.Mock())
+        self.assertEqual(purge.call_count, 1)
+
+    @override_settings(SESSION_PURGE_IN_REQUEST=False)
+    def test_disabled_by_setting(self):
+        _make_session(expired=True)
+        mw = self._middleware()
+        with mock.patch(PURGE_PATH) as purge:
+            mw(mock.Mock())
+        purge.assert_not_called()
+        self.assertEqual(Session.objects.count(), 1)
+
+    @override_settings(SESSION_PURGE_INTERVAL_SECONDS=0)
+    def test_zero_interval_disables_rather_than_running_every_request(self):
+        mw = self._middleware()
+        with mock.patch(PURGE_PATH) as purge:
+            mw(mock.Mock())
+            mw(mock.Mock())
+        purge.assert_not_called()
+
+    def test_a_quiet_interval_touches_the_cache_only_once(self):
+        """The in-process deadline exists to keep the common path free of I/O.
+
+        The cache lock alone would already stop a second purge, so nothing
+        else here can tell whether the deadline check is present. What it buys
+        is that a request which is not going to purge does no cache round-trip
+        at all - on a Redis-backed cache that is a network hop per request.
+        """
+        mw = self._middleware()
+        with mock.patch(PURGE_PATH, return_value={"status": "success"}), mock.patch(
+            "django.core.cache.cache.add", wraps=cache.add
+        ) as add:
+            for _ in range(10):
+                mw(mock.Mock())
+        self.assertEqual(add.call_count, 1)
+
+    def test_a_failing_purge_does_not_touch_the_cache_on_every_request(self):
+        """Same rule on the failure path: the deadline is pushed forward
+        before the attempt, so a purge that keeps raising still costs one
+        cache round-trip per interval rather than one per request."""
+        mw = self._middleware()
+        with mock.patch(PURGE_PATH, side_effect=RuntimeError("boom")), mock.patch(
+            "django.core.cache.cache.add", wraps=cache.add
+        ) as add:
+            for _ in range(10):
+                mw(mock.Mock())
+        self.assertEqual(add.call_count, 1)
+
+    def test_first_request_after_a_restart_is_eligible(self):
+        """A fresh instance must not start its interval in the future, or a
+        service restarting more often than the interval would never purge."""
+        self.assertEqual(self._middleware()._next_attempt, 0.0)
+
+
+@override_settings(
+    SESSION_PURGE_IN_REQUEST=True,
+    SESSION_PURGE_INTERVAL_SECONDS=86400,
+    RATELIMIT_ENABLE=False,
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+)
+class SessionPurgeThroughTheRequestStackTests(TestCase):
+    """Exercise the purge through a real request.
+
+    Everything above builds the middleware by hand, so all of it passes even
+    if SessionPurgeMiddleware is never added to MIDDLEWARE - which is the one
+    mistake that would silently disable retention entirely. This covers the
+    wiring rather than the class.
+    """
+
+    def setUp(self):
+        cache.clear()
+        Session.objects.all().delete()
+
+    def test_middleware_is_registered(self):
+        from django.conf import settings
+
+        self.assertIn("analyzer.middleware.SessionPurgeMiddleware", settings.MIDDLEWARE)
+
+    def test_an_ordinary_request_purges_expired_sessions(self):
+        expired = _make_session(expired=True)
+        live = _make_session(expired=False)
+
+        response = self.client.get("/")
+
+        self.assertEqual(response.status_code, 200)
+        keys = set(Session.objects.values_list("session_key", flat=True))
+        # The request may create a session row of its own, so assert on the
+        # two rows under test rather than the whole table.
+        self.assertNotIn(expired.session_key, keys)
+        self.assertIn(live.session_key, keys)
+
+
+class PurgeExpiredSessionsFunctionTests(TestCase):
+    """The Celery task and the middleware must share one implementation."""
+
+    def setUp(self):
+        Session.objects.all().delete()
+
+    def test_task_delegates_to_the_shared_function(self):
+        from analyzer.tasks.maintenance_tasks import purge_expired_sessions
+
+        with mock.patch(PURGE_PATH, return_value={"status": "success"}) as purge:
+            result = purge_expired_sessions()
+        purge.assert_called_once_with()
+        self.assertEqual(result, {"status": "success"})
+
+    def test_function_reports_what_it_removed(self):
+        from analyzer.tasks.maintenance_tasks import purge_expired_sessions_now
+
+        _make_session(expired=True)
+        _make_session(expired=False)
+
+        result = purge_expired_sessions_now()
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["purged"], 1)
+        self.assertEqual(result["remaining"], 1)

--- a/querygrade/celery.py
+++ b/querygrade/celery.py
@@ -32,6 +32,13 @@ app.conf.beat_schedule = {
     # django_session grows without bound - it was 4,905 rows / 1.8 MB of a
     # 12 MB database with zero registered users. Daily at 04:10 UTC, off the
     # :00/:15 marks so it never contends with monitor-ml-models.
+    #
+    # NOTE: nothing in this schedule is running right now. The worker and beat
+    # services are stopped for cost while QueryGrade has no users (issue #133),
+    # so these three entries describe what beat WOULD do, not what is
+    # happening. The session purge is the one piece that still runs, from
+    # SessionPurgeMiddleware on the web service. The other two do not.
+    # Restore both services before QueryGrade takes real traffic.
     "purge-expired-sessions": {
         "task": "analyzer.tasks.purge_expired_sessions",
         "schedule": crontab(hour=4, minute=10),

--- a/querygrade/settings.py
+++ b/querygrade/settings.py
@@ -51,7 +51,18 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "csp.middleware.CSPMiddleware",
     "analyzer.middleware.EnhancedSecurityMiddleware",
+    "analyzer.middleware.SessionPurgeMiddleware",
 ]
+
+# Expired-session retention. Normally beat's job, but the worker and beat
+# services are stopped while QueryGrade has no users (issue #133), so the web
+# process runs the purge itself at most this often. Safe to leave on when beat
+# returns - both take the same cache lock. Set SESSION_PURGE_IN_REQUEST=False
+# to turn the web-side path off and hand retention back to beat entirely.
+SESSION_PURGE_IN_REQUEST = config("SESSION_PURGE_IN_REQUEST", default=True, cast=bool)
+SESSION_PURGE_INTERVAL_SECONDS = config(
+    "SESSION_PURGE_INTERVAL_SECONDS", default=86400, cast=int
+)
 
 ROOT_URLCONF = "querygrade.urls"
 

--- a/railway.toml
+++ b/railway.toml
@@ -16,6 +16,14 @@ startCommand = "sh -c 'python manage.py collectstatic --noinput && gunicorn quer
 #   querygrade-beat    - Dockerfile.beat   - Celery beat, schedules monitor_ml_models
 #                                            every 15 min (see querygrade/celery.py)
 #
+# BOTH ARE CURRENTLY STOPPED (issue #133). Their deployments were removed to
+# save about $6.90/month while QueryGrade has no users; the service config is
+# intact, so redeploying either brings it back as configured. While they are
+# down, every async feature (log processing, batch analysis, schema analysis,
+# report generation) is non-functional, and nothing consumes the Celery
+# queues. Session retention still runs, from SessionPurgeMiddleware on this
+# service. Restore both before QueryGrade takes real traffic.
+#
 # Both services share the same env vars as the web service (DATABASE_URL,
 # REDIS_URL, etc.). Beat additionally needs ML_ALERT_RECIPIENTS once PR 3
 # of the issue-#5 stack lands.


### PR DESCRIPTION
Closes #133.

The worker and beat services are stopped to save about $6.90/month while QueryGrade has no users, which silently turned off the retention work from #128.

## Why not just restore beat

Restoring worker and beat costs about $6.90/month, which puts the Railway run rate back above the usage limits set alongside the stop. The work being paid for is deleting on the order of **100-150 session rows a day** - measured, not guessed: `django_session` currently holds 5 live rows and 0 expired, which is the observed create rate against a 1-hour `SESSION_COOKIE_AGE`, and matches the 4,905 rows the table had accumulated when #128 was written.

A full-time worker plus scheduler to run one `DELETE` a day is the wrong trade. This runs it from a service that is already up, at no additional cost.

A Railway cron service was the other candidate. It is the Railway-native pattern, but it is a repo-sourced service, so it rebuilds on every push to `main` - recurring build cost to delete 150 rows, plus a service whose schedule lives only in the dashboard.

## What this does

`SessionPurgeMiddleware` runs the purge at most once per `SESSION_PURGE_INTERVAL_SECONDS` (default daily). It is safe to leave enabled when beat returns: both take the same cache lock, so whichever runs first wins the interval.

Design constraints, in the order they matter:

1. **The common path does no I/O.** An in-process monotonic deadline decides it is not time yet, so a request that will not purge does no cache round-trip. On a Redis-backed cache that would otherwise be a network hop per request.
2. **It cannot break a request.** The purge is wrapped in a `try/except` that swallows everything. A broken cache or database stops retention, not the site.
3. **It cannot hot-loop.** The deadline is pushed forward *before* the attempt, so a failing purge costs one try per interval rather than one per request.
4. **It is correct across replicas.** `cache.add()` is atomic, so exactly one process per interval does the work.

`purge_expired_sessions` is split into a plain function plus a thin Celery task so both callers share one implementation. `SESSION_PURGE_IN_REQUEST=False` hands retention back to beat entirely.

## Making the stopped state visible

Part of #133 was that nothing about it was visible from the repo - `celery.py` reads as though all three beat entries run. The schedule and `railway.toml` now say plainly that worker and beat are stopped, that the async features are non-functional while they are, and that the session purge is the one piece still running.

## Verification

- 16 new tests. Full suite 796, OK (skipped=14), up from 780.
- **Mutation matrix over all 9 guards, no zero rows.** The first pass had three: dropping the in-process deadline, setting the deadline after the attempt, and removing the middleware from `MIDDLEWARE` all left every test green. The first two because the cache lock alone masks them - the deadline's actual rule is *not touching the cache*, so the tests now assert `cache.add` call count. The third because every test built the middleware by hand and none went through the request stack; there is now a test that does.
- Lint: no new flake8 findings on changed files (and one pre-existing `F401` in `middleware.py` is resolved, since `settings` is now used). Black and isort clean on all files touched here.